### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,8 @@
 name: Unit Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/andrewpucci/chroma11y/security/code-scanning/2](https://github.com/andrewpucci/chroma11y/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block that limits the `GITHUB_TOKEN` to the least privilege necessary. This workflow only needs to read the repository contents (for `actions/checkout`) and does not appear to require any write access to issues, PRs, or other resources. Uploading artifacts does not require repo write permissions. Therefore, the best fix is to set `contents: read` as the default for the workflow.

The minimal, non-functional-change solution is to add a top-level `permissions` block right after the `name` (or `on`) section in `.github/workflows/unit-tests.yml`, with `contents: read`. This applies to all jobs (here, just `test`) and keeps the change concise and clear. No additional imports, steps, or methods are needed, and no existing behavior will change aside from tightening token permissions.

Concretely, in `.github/workflows/unit-tests.yml`, insert:

```yaml
permissions:
  contents: read
```

at the top workflow level (same indentation as `on:` and `jobs:`), e.g. right after `name: Unit Tests`. No other lines in the file need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
