### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
Potential fix for [https://github.com/andrewpucci/chroma11y/security/code-scanning/1](https://github.com/andrewpucci/chroma11y/security/code-scanning/1)

In general, the problem is fixed by explicitly setting a `permissions` block for the workflow or for the `test` job so that `GITHUB_TOKEN` has only the minimal required scopes. For a CI job that only checks out code, interacts with Netlify, runs tests, and uploads artifacts, `contents: read` is typically sufficient; no write permissions appear needed.

The best minimal fix here, without changing existing functionality, is to add a `permissions` block at the job level under `jobs.test`, just above `runs-on`. This ensures only this job is affected and clearly documents its needs. We will set `contents: read` as recommended by CodeQL’s suggestion for a minimal starting point. None of the existing steps (checkout, setup-node, npm, playwright, waiting for Netlify, upload-artifact) require additional write permissions to repository contents; `actions/upload-artifact` does not use repository write scopes. No imports or additional definitions are required, only the YAML change within `.github/workflows/e2e.yml`.

Specifically, in `.github/workflows/e2e.yml`, at the `jobs.test` section, insert:

```yaml
    permissions:
      contents: read
```

between `test:` and `runs-on: ubuntu-latest`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
