### PR TITLE
chore: ignore windsurf skill directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ vite.config.ts.timestamp-*
 
 # IDE
 .vscode/
+.windsurf/


### PR DESCRIPTION
## Summary
- ignore `.windsurf/` so local AI skill assets stay out of version control
- no runtime or code changes

## Testing
- not applicable (gitignore only)
