### PR TITLE
feat: add Share URL button to copy palette configuration (issue #47)

### DIFF
--- a/src/lib/components/ExportButtons.dom.spec.ts
+++ b/src/lib/components/ExportButtons.dom.spec.ts
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
+import { tick } from 'svelte';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('$lib/exportUtils', () => ({
@@ -54,7 +55,8 @@ describe('ExportButtons', () => {
   });
 
   it('shows share button, copies current URL, and provides copy feedback', async () => {
-    const user = userEvent.setup();
+    vi.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     window.history.replaceState({}, '', '/?baseColor=%231862E6&themePreference=dark');
 
     render(ExportButtons);
@@ -64,5 +66,13 @@ describe('ExportButtons', () => {
     expect(copyToClipboard).toHaveBeenCalledWith(window.location.href);
     expect(announce).toHaveBeenCalledWith('Copied shareable URL to clipboard');
     expect(screen.getByText('Copied URL')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /url copied to clipboard/i })).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(2000);
+    await tick();
+
+    expect(screen.getByText('Share URL')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /copy shareable url to clipboard/i })).toBeInTheDocument();
+    vi.useRealTimers();
   });
 });

--- a/src/lib/components/ExportButtons.svelte
+++ b/src/lib/components/ExportButtons.svelte
@@ -22,13 +22,13 @@
   }: Props = $props();
 
   const theme = $derived($currentTheme);
-  let shareFeedbackVisible = $state(false);
-  let shareFeedbackTimeout: ReturnType<typeof setTimeout> | null = null;
+  let copyConfirmed = $state(false);
+  let copyFeedbackTimeout: ReturnType<typeof setTimeout> | null = null;
 
   onDestroy(() => {
-    if (shareFeedbackTimeout) {
-      clearTimeout(shareFeedbackTimeout);
-      shareFeedbackTimeout = null;
+    if (copyFeedbackTimeout) {
+      clearTimeout(copyFeedbackTimeout);
+      copyFeedbackTimeout = null;
     }
   });
 
@@ -55,15 +55,15 @@
     const url = window.location.href;
     copyToClipboard(url);
     announce('Copied shareable URL to clipboard');
-    shareFeedbackVisible = true;
+    copyConfirmed = true;
 
-    if (shareFeedbackTimeout) {
-      clearTimeout(shareFeedbackTimeout);
+    if (copyFeedbackTimeout) {
+      clearTimeout(copyFeedbackTimeout);
     }
 
-    shareFeedbackTimeout = setTimeout(() => {
-      shareFeedbackVisible = false;
-      shareFeedbackTimeout = null;
+    copyFeedbackTimeout = setTimeout(() => {
+      copyConfirmed = false;
+      copyFeedbackTimeout = null;
     }, 2000);
   }
 
@@ -83,13 +83,13 @@
 </script>
 
 <div class="export-buttons">
-  <Button onclick={shareURL} ariaLabel="Copy shareable URL to clipboard">
+  <Button
+    onclick={shareURL}
+    ariaLabel={copyConfirmed ? 'URL copied to clipboard' : 'Copy shareable URL to clipboard'}
+  >
     <Icon name="share" />
-    Share URL
+    <span class:label-enter={copyConfirmed}>{copyConfirmed ? 'Copied URL' : 'Share URL'}</span>
   </Button>
-  {#if shareFeedbackVisible}
-    <p class="share-feedback" role="status" aria-live="polite">Copied URL</p>
-  {/if}
   <Button
     onclick={exportJSON}
     disabled={neutrals.length === 0 && palettes.length === 0}
@@ -127,10 +127,18 @@
     gap: var(--space-sm);
   }
 
-  .share-feedback {
-    margin: 0;
-    color: var(--text-color);
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-medium);
+  .label-enter {
+    animation: label-pop var(--duration-fast) var(--ease-emphasized);
+  }
+
+  @keyframes label-pop {
+    from {
+      opacity: 0;
+      transform: translateY(0.1em) scale(0.98);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
Adds a Share URL button that copies the current palette configuration URL to the clipboard.

## Changes
- Added Share URL button to ExportButtons component
- Added share icon to Icon component
- Button copies current URL with all state parameters
- Includes screen reader announcement

## Benefits
- Users can easily share their palette configurations with others
- URL contains all settings (colors, theme, contrast, etc.)
- One-click copying with accessibility support

Fixes #47