### PR TITLE
feat: add Argos visual regression pipeline and Netlify smoke tests

### DIFF
--- a/.github/workflows/netlify-smoke.yml
+++ b/.github/workflows/netlify-smoke.yml
@@ -1,0 +1,52 @@
+name: Netlify Smoke Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  smoke:
+    if: github.event.pull_request.head.repo.fork == false
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install chromium --with-deps
+
+      - name: Wait for Netlify preview deployment
+        uses: jakepartusch/wait-for-netlify-action@v1.4
+        id: netlify
+        with:
+          site_name: 'chroma11y'
+          max_timeout: 600
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Netlify smoke checks
+        run: npx playwright test e2e/netlify-smoke.spec.ts --project=chromium
+        env:
+          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.netlify.outputs.url }}
+          ARGOS_UPLOAD: 'false'
+
+      - name: Upload smoke test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: netlify-smoke-report
+          path: playwright-report/
+          retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ npx playwright test --ui   # interactive UI mode
 - Test files: `e2e/*.spec.ts`
 - Runs against a production build (`npm run build && npm run preview` on port 4173)
 - Tests run in Chromium, Firefox, and WebKit
+- CI visual gating runs against local production preview in `e2e.yml`
+- Netlify deploy-preview checks run separately in `netlify-smoke.yml` (non-visual smoke coverage)
 
 ### Run everything
 

--- a/docs/visual-testing.md
+++ b/docs/visual-testing.md
@@ -1,108 +1,81 @@
-# Visual Testing with Standardized Linux Snapshots
+# Visual Testing Workflow
 
-This project runs **all E2E tests in Docker** to ensure consistency between local development and CI. The Docker environment matches GitHub Actions exactly.
+This project uses a dual workflow for E2E confidence:
+
+- **Deterministic visual regression** in CI against a local production preview (`npm run build && npm run preview`)
+- **Netlify deploy smoke checks** against deploy previews, without pixel comparison assertions
+
+Argos is integrated for PR visual review in **phase A** while keeping existing Playwright snapshot baselines in git.
 
 ## Quick Reference
 
-| Command | Description |
-|---------|-------------|
-| `npm run test:e2e` | Run E2E tests in Docker (recommended) |
-| `npm run test:e2e:update` | Regenerate snapshots + validate |
-| `npm run test:e2e:local` | Run tests locally (may differ from CI) |
+| Command                          | Description                                   |
+| -------------------------------- | --------------------------------------------- |
+| `npm run test:e2e`               | Run full E2E suite in Docker                  |
+| `npm run test:e2e:update`        | Regenerate Linux snapshots + validate         |
+| `npm run test:e2e:local`         | Run Playwright tests locally (debugging)      |
+| `npm run test:e2e:netlify-smoke` | Run non-visual deploy smoke checks (Chromium) |
 
-## Why Docker for All E2E Tests?
+## CI Pipelines
 
-- **Cross-platform consistency**: macOS and Linux render fonts/graphics differently
-- **CI parity**: Local tests match GitHub Actions exactly
-- **Cross-browser support**: Chromium, Firefox, and WebKit all tested
-- **No flaky tests**: Same environment = same results
+### 1) Required Visual Gate (`.github/workflows/e2e.yml`)
 
-## Generating Snapshots
+- Runs Playwright against local production preview (deterministic)
+- Uses committed `toHaveScreenshot()` baselines
+- Uploads Argos captures for trusted PRs only:
+  - `ARGOS_UPLOAD=true` on same-repo PRs
+  - `ARGOS_UPLOAD=false` on fork PRs and manual dispatch
 
-### After UI Changes
+### 2) Netlify Smoke (`.github/workflows/netlify-smoke.yml`)
+
+- Waits for Netlify deploy preview URL
+- Runs `e2e/netlify-smoke.spec.ts` only
+- Verifies load and core functional paths, no visual baseline assertions
+
+## Phase A Migration Behavior
+
+During phase A we keep both mechanisms for visual checks:
+
+1. Existing Playwright `toHaveScreenshot()` assertions (git baselines)
+2. Argos captures through `e2e/visual.ts` in Chromium only when `ARGOS_UPLOAD=true`
+
+This gives rollback safety while Argos review flow stabilizes.
+
+## Snapshot Baselines (Current Source in Phase A)
+
+Snapshots are still generated in Docker and committed:
+
 ```bash
-# Regenerate all snapshots and validate
 npm run test:e2e:update
 ```
 
-### Update Only (Skip Validation)
-```bash
-./scripts/test-linux-snapshots.sh --update-only
-```
+Manual commands:
 
-### Manual Docker Commands
 ```bash
-# Build environment
 docker compose build
-
-# Update snapshots
 docker compose run --rm update-snapshots
-
-# Run tests
 docker compose run --rm test
 ```
 
-## File Structure
+## Baseline Reseeding for Argos
 
-```
-e2e/
-├── focus-indicators.spec.ts-snapshots/
-│   ├── focus-indicator-light-chromium.png
-│   ├── focus-indicator-light-firefox.png
-│   ├── focus-indicator-light-webkit.png
-│   └── ...
-└── ...
-```
-
-## Workflow
-
-1. **Make UI changes** in development
-2. **Regenerate snapshots**: `npm run test:e2e:update`
-3. **Review** the generated `.png` files
-4. **Commit** the snapshots to version control
-5. **CI passes**: Uses the same Docker environment
-
-## Docker Environment
-
-The Docker setup replicates CI exactly:
-- `ubuntu:22.04` (same as GitHub Actions `ubuntu-latest`)
-- Node.js 24 (matches CI configuration)
-- All Playwright browsers: Chromium, Firefox, WebKit
-- Playwright handles build + preview server automatically
-
-## Configuration
-
-`playwright.config.ts`:
-- `maxDiffPixelRatio: 0.02` for small tolerance
-- `webServer` config builds and starts preview server
-- All three browser projects enabled
-
-`docker-compose.yml`:
-- `update-snapshots` service: generates new baselines
-- `test` service: validates against existing snapshots
+The E2E workflow supports manual dispatch (`workflow_dispatch`) to run a non-upload baseline-safe pass.
+Use this with a run from `main` when you need to reseed/refresh Argos reference behavior.
 
 ## Troubleshooting
 
-### Docker not running
-```bash
-# Ensure Docker Desktop is running, then:
-docker compose build
-```
+### Visual diffs on Netlify but not local preview
 
-### Tests fail after UI changes
+Expected in some cases due to deploy-environment rendering differences. Required visual gating is local deterministic CI; deploy checks belong in the smoke workflow.
+
+### Fork PRs do not show Argos upload
+
+Expected. Fork PRs intentionally skip Argos upload to avoid secret/integration constraints.
+
+### Updating UI changed expected snapshots
+
+Regenerate in Docker:
+
 ```bash
 npm run test:e2e:update
-# Review and commit the updated snapshots
 ```
-
-### Need to debug locally
-```bash
-# Run tests locally (results may differ from CI)
-npm run test:e2e:local
-
-# Or with UI mode
-npx playwright test --ui
-```
-
-### Slow first run
-The first `docker compose build` downloads browsers (~500MB). Subsequent runs use cached layers.

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -2,6 +2,11 @@
 
 Playwright end-to-end tests that run against a production build. **All E2E tests run in Docker** to ensure consistency between local development and CI.
 
+CI uses two pipelines:
+
+- `e2e.yml`: deterministic visual gate against local production preview
+- `netlify-smoke.yml`: deploy-preview functional smoke checks (no visual baselines)
+
 ## Setup
 
 Run E2E tests in Docker (recommended):
@@ -20,6 +25,12 @@ Run locally for debugging (results may differ from CI):
 
 ```sh
 npm run test:e2e:local
+```
+
+Run deploy-preview smoke tests only:
+
+```sh
+npm run test:e2e:netlify-smoke
 ```
 
 See `docs/visual-testing.md` for full Docker workflow documentation.
@@ -92,7 +103,13 @@ Prefer these selector strategies in order:
 
 ## Visual comparisons (snapshots)
 
-Visual regression tests use Playwright's `toHaveScreenshot()` API. Snapshots are stored in `{test-file}.spec.ts-snapshots/` directories and **must be committed** to version control.
+Visual regression tests use Playwright's `toHaveScreenshot()` API. Snapshots are stored in `{test-file}.spec.ts-snapshots/` directories and **must be committed** to version control during phase A.
+
+Argos capture is also enabled in phase A through `e2e/visual.ts`:
+
+- Upload is gated by `ARGOS_UPLOAD=true`
+- Capture is restricted to Chromium
+- Fork PRs run tests but skip Argos upload
 
 ### Generating snapshots
 
@@ -109,6 +126,7 @@ npm run test:e2e:update
 - Snapshots include browser suffix automatically: `palette-grid-chromium.png`, `palette-grid-firefox.png`, `palette-grid-webkit.png`
 - All snapshots are Linux-generated for consistency across local dev and CI
 - Use `stylePath` option to hide dynamic content (timestamps, animations)
+- For new visual tests in phase A, call `maybeCaptureArgosVisual(...)` before `toHaveScreenshot(...)`
 
 ### Current coverage
 
@@ -138,5 +156,6 @@ When adding a new E2E test file:
 - **`export-validation.spec.ts`** — Export format correctness
 - **`focus-indicators.spec.ts`** — Focus ring visibility, behavior + visual regression
 - **`mobile-responsiveness.spec.ts`** — Responsive layout testing + visual regression
+- **`netlify-smoke.spec.ts`** — Deploy-preview functional smoke checks (no visual assertions)
 - **`persistence.spec.ts`** — URL and localStorage state persistence
 - **`ui-interactions.spec.ts`** — General UI interaction flows + visual regression (themes, palettes)

--- a/e2e/bezier-editor.spec.ts
+++ b/e2e/bezier-editor.spec.ts
@@ -5,6 +5,7 @@
 
 import { test, expect } from '@playwright/test';
 import { waitForAppReady } from './test-utils';
+import { maybeCaptureArgosVisual } from './visual';
 
 test.describe('Bezier Editor', () => {
   test.beforeEach(async ({ page }) => {
@@ -44,8 +45,14 @@ test.describe('Bezier Editor', () => {
   });
 
   test.describe('Visual regression', () => {
-    test('bezier curve visual appearance', async ({ page }) => {
+    test('bezier curve visual appearance', async ({ page }, testInfo) => {
       const bezierEditor = page.locator('.bezier-editor');
+      await maybeCaptureArgosVisual({
+        page,
+        testInfo,
+        name: 'bezier-editor-default',
+        element: bezierEditor
+      });
       await expect(bezierEditor).toHaveScreenshot('bezier-editor-default.png');
     });
   });

--- a/e2e/focus-indicators.spec.ts
+++ b/e2e/focus-indicators.spec.ts
@@ -7,6 +7,7 @@
 
 import { test, expect } from '@playwright/test';
 import { waitForAppReady } from './test-utils';
+import { maybeCaptureArgosVisual } from './visual';
 
 test.describe('Focus Indicators', () => {
   test.describe('Visual regression', () => {
@@ -15,15 +16,21 @@ test.describe('Focus Indicators', () => {
       await waitForAppReady(page);
     });
 
-    test('focus indicator appearance in light mode', async ({ page }) => {
+    test('focus indicator appearance in light mode', async ({ page }, testInfo) => {
       const hexInput = page.locator('#baseColorHex');
       await hexInput.focus();
       await page.keyboard.press('Tab');
       await page.keyboard.press('Shift+Tab');
+      await maybeCaptureArgosVisual({
+        page,
+        testInfo,
+        name: 'focus-indicator-light',
+        element: hexInput
+      });
       await expect(hexInput).toHaveScreenshot('focus-indicator-light.png');
     });
 
-    test('focus indicator appearance in dark mode', async ({ page }) => {
+    test('focus indicator appearance in dark mode', async ({ page }, testInfo) => {
       await page.locator('#theme-preference').selectOption('dark');
       await page.waitForFunction(
         () => document.documentElement.getAttribute('data-theme') === 'dark'
@@ -33,6 +40,12 @@ test.describe('Focus Indicators', () => {
       await hexInput.focus();
       await page.keyboard.press('Tab');
       await page.keyboard.press('Shift+Tab');
+      await maybeCaptureArgosVisual({
+        page,
+        testInfo,
+        name: 'focus-indicator-dark',
+        element: hexInput
+      });
       await expect(hexInput).toHaveScreenshot('focus-indicator-dark.png');
     });
   });

--- a/e2e/mobile-responsiveness.spec.ts
+++ b/e2e/mobile-responsiveness.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { waitForAppReady } from './test-utils';
+import { maybeCaptureArgosVisual } from './visual';
 
 const MOBILE_VIEWPORTS = {
   iPhone_SE: { width: 375, height: 667 },
@@ -11,19 +12,31 @@ const MOBILE_VIEWPORTS = {
 
 test.describe('Mobile Responsiveness', () => {
   test.describe('Visual regression', () => {
-    test('mobile layout appearance (iPhone SE)', async ({ page }) => {
+    test('mobile layout appearance (iPhone SE)', async ({ page }, testInfo) => {
       await page.setViewportSize(MOBILE_VIEWPORTS.iPhone_SE);
       await page.goto('/');
       await waitForAppReady(page);
+      await maybeCaptureArgosVisual({
+        page,
+        testInfo,
+        name: 'mobile-layout-iphone-se',
+        fullPage: true
+      });
       await expect(page).toHaveScreenshot('mobile-layout-iphone-se.png', {
         fullPage: true
       });
     });
 
-    test('mobile layout appearance (small phone 320px)', async ({ page }) => {
+    test('mobile layout appearance (small phone 320px)', async ({ page }, testInfo) => {
       await page.setViewportSize(MOBILE_VIEWPORTS.Small_Phone);
       await page.goto('/');
       await waitForAppReady(page);
+      await maybeCaptureArgosVisual({
+        page,
+        testInfo,
+        name: 'mobile-layout-320px',
+        fullPage: true
+      });
       await expect(page).toHaveScreenshot('mobile-layout-320px.png', {
         fullPage: true
       });

--- a/e2e/netlify-smoke.spec.ts
+++ b/e2e/netlify-smoke.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Netlify smoke tests run against deploy previews only.
+ * These checks intentionally avoid visual snapshot assertions.
+ */
+
+import { test, expect } from '@playwright/test';
+import { waitForAppReady } from './test-utils';
+
+test.describe('Netlify Smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+  });
+
+  test('loads application and key controls', async ({ page }) => {
+    await expect(page.locator('#main-heading')).toContainText('Chroma11y');
+    await expect(page.locator('#baseColor')).toBeVisible();
+    await expect(page.getByTestId('generated-palettes')).toBeVisible();
+  });
+
+  test('updates palette when base color changes', async ({ page }) => {
+    const paletteHexes = page
+      .getByTestId('generated-palettes')
+      .locator('.swatches')
+      .first()
+      .locator('.hex');
+    const initialHex = await paletteHexes.nth(5).textContent();
+
+    await page.locator('#baseColor').fill('#00ff00');
+
+    await page.waitForFunction(
+      (before) => {
+        const hex = document.querySelector(
+          '[data-testid="generated-palettes"] .swatches .hex:nth-child(6)'
+        )?.textContent;
+        return hex !== before;
+      },
+      initialHex,
+      { timeout: 5000 }
+    );
+
+    const updatedHex = await paletteHexes.nth(5).textContent();
+    expect(updatedHex).not.toBe(initialHex);
+  });
+
+  test('can export JSON file', async ({ page }) => {
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Export JSON design tokens' }).click();
+
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.json$/);
+  });
+});

--- a/e2e/ui-interactions.spec.ts
+++ b/e2e/ui-interactions.spec.ts
@@ -5,6 +5,7 @@
 
 import { test, expect } from '@playwright/test';
 import { waitForAppReady } from './test-utils';
+import { maybeCaptureArgosVisual } from './visual';
 
 test.describe('UI Interactions', () => {
   test.beforeEach(async ({ page }) => {
@@ -13,29 +14,53 @@ test.describe('UI Interactions', () => {
   });
 
   test.describe('Visual regression', () => {
-    test('app appearance in light theme', async ({ page }) => {
+    test('app appearance in light theme', async ({ page }, testInfo) => {
+      await maybeCaptureArgosVisual({
+        page,
+        testInfo,
+        name: 'app-light-theme',
+        fullPage: true
+      });
       await expect(page).toHaveScreenshot('app-light-theme.png', {
         fullPage: true
       });
     });
 
-    test('app appearance in dark theme', async ({ page }) => {
+    test('app appearance in dark theme', async ({ page }, testInfo) => {
       await page.locator('#theme-preference').selectOption('dark');
       await page.waitForFunction(
         () => document.documentElement.getAttribute('data-theme') === 'dark'
       );
+      await maybeCaptureArgosVisual({
+        page,
+        testInfo,
+        name: 'app-dark-theme',
+        fullPage: true
+      });
       await expect(page).toHaveScreenshot('app-dark-theme.png', {
         fullPage: true
       });
     });
 
-    test('palette grid visual appearance', async ({ page }) => {
+    test('palette grid visual appearance', async ({ page }, testInfo) => {
       const palettes = page.getByTestId('generated-palettes');
+      await maybeCaptureArgosVisual({
+        page,
+        testInfo,
+        name: 'palette-grid',
+        element: palettes
+      });
       await expect(palettes).toHaveScreenshot('palette-grid.png');
     });
 
-    test('neutral palette visual appearance', async ({ page }) => {
+    test('neutral palette visual appearance', async ({ page }, testInfo) => {
       const neutralPalette = page.getByTestId('neutral-palette');
+      await maybeCaptureArgosVisual({
+        page,
+        testInfo,
+        name: 'neutral-palette',
+        element: neutralPalette
+      });
       await expect(neutralPalette).toHaveScreenshot('neutral-palette.png');
     });
   });

--- a/e2e/visual.ts
+++ b/e2e/visual.ts
@@ -1,0 +1,28 @@
+import { argosScreenshot } from '@argos-ci/playwright';
+import type { Locator, Page, TestInfo } from '@playwright/test';
+
+interface VisualCaptureOptions {
+  page: Page;
+  testInfo: TestInfo;
+  name: string;
+  element?: Locator;
+  fullPage?: boolean;
+}
+
+/**
+ * Captures a visual snapshot in Argos during CI for trusted PRs.
+ * Phase A keeps Playwright file-based snapshots and adds Argos in parallel.
+ */
+export async function maybeCaptureArgosVisual(options: VisualCaptureOptions): Promise<void> {
+  const isChromium = options.testInfo.project.name === 'chromium';
+  const shouldUpload = process.env.ARGOS_UPLOAD === 'true';
+
+  if (!isChromium || !shouldUpload) {
+    return;
+  }
+
+  await argosScreenshot(options.page, options.name, {
+    element: options.element,
+    fullPage: options.fullPage
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dompurify": "^3.3.1"
       },
       "devDependencies": {
+        "@argos-ci/playwright": "^6.4.2",
         "@eslint/compat": "^2.0.2",
         "@eslint/js": "^10.0.0",
         "@lhci/cli": "^0.15.1",
@@ -68,6 +69,104 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@argos-ci/api-client": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@argos-ci/api-client/-/api-client-0.16.0.tgz",
+      "integrity": "sha512-BG6g+AZABKN8W2syzfPWKhPxxrAB9Wjp2iNS11R4IskHDV6T41+qeQDpT88GOq6eUZ64Sjzoh/nXG+9EpNxtfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "openapi-fetch": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@argos-ci/browser": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@argos-ci/browser/-/browser-5.1.2.tgz",
+      "integrity": "sha512-eQqtM54Vh83++Dac5+7ml4YXKW/KnUHRQWjTZ+VGeXfOJdjnZa4JjfVL6fnFG6CKrXjCK5dd9gcZRmbVpbt8rA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@argos-ci/core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@argos-ci/core/-/core-5.1.1.tgz",
+      "integrity": "sha512-RI5pYb5wmWUoXzWefNCjKSqGA3BroUB2ac9awlYV3McJjSAW8nCGJUt2Eds90Shkp+i4S6KbMLnLG56slhTCsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@argos-ci/api-client": "0.16.0",
+        "@argos-ci/util": "3.2.0",
+        "convict": "^6.2.4",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
+        "mime-types": "^3.0.2",
+        "sharp": "^0.34.5",
+        "tmp": "^0.2.5"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@argos-ci/core/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@argos-ci/core/node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@argos-ci/playwright": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@argos-ci/playwright/-/playwright-6.4.2.tgz",
+      "integrity": "sha512-0HE4rmgx2/znlMUi3z0Bp8OD7u7zNls9SlljL+qTVoWQRW22sDvpmRdZpjzb4pEjoe6onqPTDOqm5/f8QYHMwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@argos-ci/browser": "5.1.2",
+        "@argos-ci/core": "5.1.1",
+        "@argos-ci/util": "3.2.0",
+        "chalk": "^5.6.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@argos-ci/util": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@argos-ci/util/-/util-3.2.0.tgz",
+      "integrity": "sha512-/Bn0qCH8VsdPv5WB9TUEf3oTgsIqsTMUEjPVDopHLzKK+j7nQYGOF3MnN7VhBow82BXeStBfJCS3UiZ6cgxRlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "4.1.2",
@@ -334,6 +433,17 @@
       "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1110,6 +1220,496 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
+      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1233,6 +1833,44 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@paulirish/trace_engine": {
@@ -3265,6 +3903,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -3390,6 +4041,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chardet": {
@@ -3679,6 +4343,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/convict": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.4.tgz",
+      "integrity": "sha512-qN60BAwdMVdofckX7AlohVJ2x9UvjTNoKVXCL2LxFk1l7757EJqf1nySdMkPQer0bt8kQ5lQiyZ9/2NvrFBuwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "yargs-parser": "^20.2.7"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/convict/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/cookie": {
@@ -4707,6 +5395,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4720,6 +5438,16 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
@@ -4783,6 +5511,19 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/finalhandler": {
@@ -5433,6 +6174,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-obj": {
@@ -6301,6 +7052,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lookup-closest-locale": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
@@ -6420,6 +7178,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/metaviewport-parser": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.3.0.tgz",
@@ -6435,6 +7203,33 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime": {
@@ -6765,6 +7560,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openapi-fetch": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.15.2.tgz",
+      "integrity": "sha512-rdYTzUmSsJevmNqg7fwUVGuKc2Gfb9h6ph74EVPkPfIGJaZTfqdIbJahtbJ3qg1LKinln30hqZniLnKpH0RJBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -7390,6 +8202,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -7492,6 +8325,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -7572,6 +8416,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
@@ -7739,6 +8607,51 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -8331,6 +9244,19 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -36,9 +36,11 @@
     "test:e2e": "docker compose run --rm test",
     "test:e2e:update": "./scripts/test-linux-snapshots.sh",
     "test:e2e:local": "playwright test",
+    "test:e2e:netlify-smoke": "playwright test e2e/netlify-smoke.spec.ts --project=chromium",
     "test:lighthouse": "rm -rf lighthouse-report .lighthouseci && lhci autorun; open $(node -e \"const m=require('./lighthouse-report/manifest.json');console.log(m.find(r=>r.isRepresentativeRun).htmlPath)\")"
   },
   "devDependencies": {
+    "@argos-ci/playwright": "^6.4.2",
     "@eslint/compat": "^2.0.2",
     "@eslint/js": "^10.0.0",
     "@lhci/cli": "^0.15.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { createArgosReporterOptions } from '@argos-ci/playwright/reporter';
 
 const baseURL = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:4173';
 
@@ -18,8 +19,7 @@ export default defineConfig({
   },
   use: {
     baseURL,
-    navigationTimeout:
-      process.env.CI || process.env.PLAYWRIGHT_TEST_BASE_URL ? 60000 : 15000,
+    navigationTimeout: process.env.CI || process.env.PLAYWRIGHT_TEST_BASE_URL ? 60000 : 15000,
     actionTimeout: 10000,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
@@ -40,9 +40,15 @@ export default defineConfig({
     }
   ],
   reporter: [
+    [process.env.CI ? 'dot' : 'list'],
+    [
+      '@argos-ci/playwright/reporter',
+      createArgosReporterOptions({
+        uploadToArgos: process.env.ARGOS_UPLOAD === 'true'
+      })
+    ],
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'playwright-report/results.json' }],
-    ['junit', { outputFile: 'playwright-report/results.xml' }],
-    ['list']
+    ['junit', { outputFile: 'playwright-report/results.xml' }]
   ]
 });


### PR DESCRIPTION
## Summary
Implements the Argos phase-A visual testing rollout while keeping existing Playwright snapshot assertions.

## What this PR adds
- Integrates Argos Playwright reporter with env-gated upload (`ARGOS_UPLOAD`)
- Adds `e2e/visual.ts` helper and wires Argos capture into all 9 visual checkpoints (Chromium-only)
- Adds dedicated Netlify smoke workflow and `e2e/netlify-smoke.spec.ts` (non-visual)
- Updates docs and AGENTS guidance for dual pipeline behavior
- Adds `@argos-ci/playwright` dependency and `test:e2e:netlify-smoke` script

## Why
- Keeps required visual gating deterministic (local production preview)
- Preserves deploy-environment coverage via separate smoke checks
- Enables Argos review without forcing immediate removal of git snapshot baselines

## Notes
- Fork PRs run tests but skip Argos upload (`ARGOS_UPLOAD=false`)
- Full baseline migration away from committed PNGs remains a later phase