### PR TITLE
chore: refresh Argos baseline flow and docs for main pushes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,8 @@ name: E2E Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       argos_upload:
@@ -46,6 +48,13 @@ jobs:
         run: npx playwright test
         env:
           ARGOS_UPLOAD: ${{ github.event.inputs.argos_upload == 'true' && 'true' || 'false' }}
+          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
+
+      - name: Run Playwright tests (main branch baseline refresh)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: npx playwright test
+        env:
+          ARGOS_UPLOAD: 'true'
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
 
       - name: Upload Playwright report

--- a/docs/visual-testing.md
+++ b/docs/visual-testing.md
@@ -22,9 +22,10 @@ Argos is integrated for PR visual review in **phase A** while keeping existing P
 
 - Runs Playwright against local production preview (deterministic)
 - Uses committed `toHaveScreenshot()` baselines
-- Uploads Argos captures for trusted PRs only:
+- Uploads Argos captures when:
   - `ARGOS_UPLOAD=true` on same-repo PRs
-  - `ARGOS_UPLOAD=false` on fork PRs and manual dispatch
+  - `ARGOS_UPLOAD=true` on pushes to `main` (post-merge baseline refresh)
+  - `ARGOS_UPLOAD=false` on fork PRs by default
 
 ### 2) Netlify Smoke (`.github/workflows/netlify-smoke.yml`)
 
@@ -59,8 +60,11 @@ docker compose run --rm test
 
 ## Baseline Reseeding for Argos
 
-The E2E workflow supports manual dispatch (`workflow_dispatch`) to run a non-upload baseline-safe pass.
-Use this with a run from `main` when you need to reseed/refresh Argos reference behavior.
+Argos baseline refresh now happens automatically on pushes to `main` in the E2E workflow.
+Manual dispatch (`workflow_dispatch`) is still available for ad-hoc runs:
+
+- set `argos_upload=true` to upload captures to Argos
+- leave it `false` for a non-upload validation run
 
 ## Troubleshooting
 

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -109,6 +109,8 @@ Argos capture is also enabled in phase A through `e2e/visual.ts`:
 
 - Upload is gated by `ARGOS_UPLOAD=true`
 - Capture is restricted to Chromium
+- Same-repo PRs upload to Argos
+- Pushes to `main` upload to Argos for baseline refresh
 - Fork PRs run tests but skip Argos upload
 
 ### Generating snapshots
@@ -134,7 +136,6 @@ Visual regression tests are implemented in:
 
 - **`focus-indicators.spec.ts`** — Focus ring appearance (light/dark)
 - **`ui-interactions.spec.ts`** — Full app themes, palette grid, neutral palette
-- **`mobile-responsiveness.spec.ts`** — Mobile layouts (iPhone SE, 320px)
 - **`bezier-editor.spec.ts`** — Bezier curve editor appearance
 
 Snapshots are stored in `*.spec.ts-snapshots/` directories and committed to version control.
@@ -155,7 +156,7 @@ When adding a new E2E test file:
 - **`design-tokens.spec.ts`** — Design token system runtime behavior
 - **`export-validation.spec.ts`** — Export format correctness
 - **`focus-indicators.spec.ts`** — Focus ring visibility, behavior + visual regression
-- **`mobile-responsiveness.spec.ts`** — Responsive layout testing + visual regression
+- **`mobile-responsiveness.spec.ts`** — Responsive layout and touch target behavior (non-visual assertions)
 - **`netlify-smoke.spec.ts`** — Deploy-preview functional smoke checks (no visual assertions)
 - **`persistence.spec.ts`** — URL and localStorage state persistence
 - **`ui-interactions.spec.ts`** — General UI interaction flows + visual regression (themes, palettes)

--- a/e2e/visual.ts
+++ b/e2e/visual.ts
@@ -10,7 +10,7 @@ interface VisualCaptureOptions {
 }
 
 /**
- * Captures a visual snapshot in Argos during CI for trusted PRs.
+ * Captures a visual snapshot in Argos during CI for trusted PRs and main pushes.
  * Phase A keeps Playwright file-based snapshots and adds Argos in parallel.
  */
 export async function maybeCaptureArgosVisual(options: VisualCaptureOptions): Promise<void> {


### PR DESCRIPTION
## Summary
- trigger E2E workflow on pushes to `main`
- run Playwright on `main` pushes with `ARGOS_UPLOAD=true` to refresh Argos baselines after merge
- update Argos capture helper docs to reflect `main` push uploads
- update visual-testing documentation and E2E AGENTS docs to match current CI behavior and visual test coverage

## Files
- `.github/workflows/e2e.yml`
- `e2e/visual.ts`
- `docs/visual-testing.md`
- `e2e/AGENTS.md`