### PR TITLE
feat: onboarding help and getting started guide (#40)

### DIFF
--- a/e2e/ui-interactions.spec.ts
+++ b/e2e/ui-interactions.spec.ts
@@ -76,6 +76,35 @@ test.describe('UI Interactions', () => {
     });
   });
 
+  test.describe('Getting Started Guide', () => {
+    test('keeps keyboard focus inside the modal and returns focus to the Help trigger', async ({
+      page
+    }) => {
+      const helpButton = page.getByRole('button', { name: 'Open Getting Started guide' });
+      await helpButton.click();
+
+      const dialog = page.getByRole('dialog', { name: 'Getting Started' });
+      await expect(dialog).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Close Getting Started guide' })).toBeFocused();
+
+      for (let index = 0; index < 12; index += 1) {
+        await page.keyboard.press('Tab');
+        await expect
+          .poll(async () => {
+            return await page.evaluate(() =>
+              Boolean(document.activeElement?.closest('#getting-started-dialog'))
+            );
+          })
+          .toBe(true);
+      }
+
+      await page.keyboard.press('Escape');
+
+      await expect(dialog).toBeHidden();
+      await expect(helpButton).toBeFocused();
+    });
+  });
+
   test.describe('Constraints Panel', () => {
     test('keeps closed constraints content out of the tab order until expanded and supports filter and enabled toggles', async ({
       page

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0",
       "dependencies": {
+        "@floating-ui/dom": "^1.7.6",
         "@fontsource-variable/atkinson-hyperlegible-mono": "^5.2.5",
         "@fontsource-variable/atkinson-hyperlegible-next": "^5.2.6",
         "@tabler/icons-svelte-runes": "^3.41.1",
@@ -914,6 +915,31 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@fontsource-variable/atkinson-hyperlegible-mono": {
       "version": "5.2.5",
@@ -3129,6 +3155,7 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "defaults and fully supports es6-module"
   ],
   "dependencies": {
+    "@floating-ui/dom": "^1.7.6",
     "@fontsource-variable/atkinson-hyperlegible-mono": "^5.2.5",
     "@fontsource-variable/atkinson-hyperlegible-next": "^5.2.6",
     "@tabler/icons-svelte-runes": "^3.41.1",

--- a/src/lib/components/AppHeader.svelte
+++ b/src/lib/components/AppHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { HistoryMenuEntry } from '$lib/history';
+  import { gettingStartedDialog, openGettingStartedGuide } from '$lib/help/helpDialogStore';
   import Brand from './Brand.svelte';
   import Button from './Button.svelte';
   import Icon from './Icon.svelte';
@@ -30,12 +31,28 @@
     onUndoJump = () => {},
     onRedoJump = () => {}
   }: Props = $props();
+
+  let gettingStartedOpen = $derived($gettingStartedDialog.open);
+
+  function handleHelpOpen(event: MouseEvent): void {
+    openGettingStartedGuide(event.currentTarget as HTMLElement);
+  }
 </script>
 
 <header class="topbar">
   <div class="topbar-inner" bind:this={bindInner}>
     <Brand />
     <div class="history-controls" aria-label="History controls">
+      <Button
+        onclick={handleHelpOpen}
+        variant="secondary"
+        ariaLabel="Open Getting Started guide"
+        ariaControls="getting-started-dialog"
+        ariaExpanded={gettingStartedOpen}
+      >
+        <Icon name="help" />
+        <span>Help</span>
+      </Button>
       <Button onclick={onReset} variant="ghost" ariaLabel="Reset all settings to defaults">
         <Icon name="reset" />
         <span>Reset</span>

--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -2,7 +2,7 @@
   import type { Snippet } from 'svelte';
 
   interface Props {
-    onclick?: () => void;
+    onclick?: (event: MouseEvent) => void;
     disabled?: boolean;
     variant?: 'primary' | 'secondary' | 'ghost';
     compact?: boolean;

--- a/src/lib/components/CheckboxRow.svelte
+++ b/src/lib/components/CheckboxRow.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import HelpTooltip from './HelpTooltip.svelte';
+
   interface Props {
     id: string;
     label: string;
@@ -39,21 +41,8 @@
   />
   <span class="check-label-with-help">
     <label class="check-label" for={id}>{label}</label>
-    {#if helpText && helpLabel}
-      <span class="help-popover">
-        <button
-          type="button"
-          class="info-button"
-          aria-label={helpLabel}
-          aria-describedby={helpId}
-          {disabled}
-        >
-          <span aria-hidden="true">i</span>
-        </button>
-        <span id={helpId} class="help-tooltip" role="tooltip">
-          {helpText}
-        </span>
-      </span>
+    {#if helpText && helpLabel && helpId}
+      <HelpTooltip id={helpId} label={helpLabel} text={helpText} {disabled} />
     {/if}
   </span>
 </div>
@@ -83,65 +72,5 @@
     height: var(--touch-target-min);
     margin: 0;
     accent-color: var(--accent);
-  }
-
-  .help-popover {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-  }
-
-  .info-button {
-    width: var(--touch-target-min);
-    min-width: var(--touch-target-min);
-    height: var(--touch-target-min);
-    border-radius: 50%;
-    border: 1px solid var(--border);
-    background: var(--bg-primary);
-    color: var(--text-secondary);
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-semibold);
-    line-height: 1;
-    cursor: help;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
-  }
-
-  .info-button:disabled {
-    opacity: 0.55;
-    cursor: not-allowed;
-  }
-
-  .help-tooltip {
-    position: absolute;
-    inset-block-start: calc(100% + var(--space-xs));
-    inset-inline-start: 0;
-    z-index: 20;
-    inline-size: min(40ch, calc(100vw - var(--space-xl)));
-    padding: var(--space-sm) var(--space-md);
-    border-radius: var(--radius-md);
-    border: 1px solid var(--border);
-    background: var(--bg-primary);
-    color: var(--text-primary);
-    font-size: var(--font-size-sm);
-    line-height: var(--line-height-normal);
-    box-shadow: 0 6px 16px color-mix(in oklab, black 14%, transparent);
-    visibility: hidden;
-    opacity: 0;
-    transform: translateY(-2px);
-    pointer-events: none;
-    transition:
-      opacity var(--transition-fast),
-      transform var(--transition-fast),
-      visibility var(--transition-fast);
-  }
-
-  .help-popover:hover .help-tooltip,
-  .help-popover:focus-within .help-tooltip {
-    visibility: visible;
-    opacity: 1;
-    transform: translateY(0);
   }
 </style>

--- a/src/lib/components/ColorControls.dom.spec.ts
+++ b/src/lib/components/ColorControls.dom.spec.ts
@@ -188,4 +188,23 @@ describe('ColorControls', () => {
     expect(p1XInput.value).toBe('0.16');
     expect(p2YInput.value).toBe('0.38');
   });
+
+  it('renders help tooltip triggers for major color controls', () => {
+    render(ColorControls, {
+      props: {
+        warmth: 12,
+        warmthHue: 180,
+        advancedOpen: true
+      }
+    });
+
+    expect(screen.getByRole('button', { name: 'Explain Base Color' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explain Warmth Amount' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explain Custom Warmth Hue' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explain Warmth Hue' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explain Saturation' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explain Number of Colors' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explain Number of Palettes' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explain Bezier Curve' })).toBeInTheDocument();
+  });
 });

--- a/src/lib/components/ColorControls.svelte
+++ b/src/lib/components/ColorControls.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
+  import { HELP_TOPICS } from '$lib/help/helpContent';
   import BezierEditor from './BezierEditor.svelte';
   import CheckboxRow from './CheckboxRow.svelte';
+  import HelpTooltip from './HelpTooltip.svelte';
   import Icon from './Icon.svelte';
   import SliderNumberField from './SliderNumberField.svelte';
   import { getChromaMultiplierBounds } from '$lib/chromaMultiplier';
@@ -241,7 +243,14 @@
   <section class="control-subsection">
     <div class="control-grid">
       <div class="field base-color">
-        <label class="label" for="baseColor">Base Color</label>
+        <div class="label-row">
+          <label class="label" for="baseColor">Base Color</label>
+          <HelpTooltip
+            id="base-color-help"
+            label="Explain Base Color"
+            text={HELP_TOPICS.baseColor.tooltip}
+          />
+        </div>
         <div class="base-color-row">
           <input
             id="baseColor"
@@ -273,6 +282,9 @@
         step={warmthRange.step}
         bind:value={warmth}
         groupHelpText={warmthHelpText}
+        infoButtonLabel={`Explain ${warmthLabel}`}
+        infoTooltipId="warmth-help"
+        infoTooltipText={HELP_TOPICS.warmth.tooltip}
         onRangeChange={onWarmthCommit}
         onNumberInput={clampWarmthFromInput}
         onNumberChange={onWarmthCommit}
@@ -286,6 +298,8 @@
             label="Custom Warmth Hue"
             checked={warmthHueEnabled}
             ariaLabel="Custom Warmth Hue"
+            helpLabel="Explain Custom Warmth Hue"
+            helpText={HELP_TOPICS.customWarmthHue.tooltip}
             onChange={handleWarmthHueToggle}
           />
           {#if warmthHueEnabled}
@@ -298,6 +312,9 @@
               step={WARMTH_HUE_RANGE.step}
               bind:value={warmthHueValue}
               groupHelpText="Hue angle 0 to 359 degrees. Overrides the default warm/cool hue direction."
+              infoButtonLabel="Explain Warmth Hue"
+              infoTooltipId="warmth-hue-help"
+              infoTooltipText={HELP_TOPICS.customWarmthHue.tooltip}
               onRangeChange={handleWarmthHueRangeChange}
               onNumberInput={clampWarmthHueFromInput}
               onNumberChange={onWarmthHueCommit}
@@ -316,6 +333,9 @@
         step={SATURATION_RANGE.step}
         bind:value={chromaMultiplier}
         groupHelpText="Normalized range 0 to 1. Use slider for coarse adjustment and number input for precise adjustment."
+        infoButtonLabel="Explain Saturation"
+        infoTooltipId="saturation-help"
+        infoTooltipText={HELP_TOPICS.saturation.tooltip}
         onRangeChange={onSaturationCommit}
         onNumberInput={clampSaturationFromInput}
         onNumberChange={onSaturationCommit}
@@ -331,6 +351,9 @@
         step={NUM_COLORS_RANGE.step}
         bind:value={numColors}
         groupHelpText={`Range ${NUM_COLORS_RANGE.min} to ${NUM_COLORS_RANGE.max}. Use slider for coarse adjustment and number input for precise adjustment.`}
+        infoButtonLabel="Explain Number of Colors"
+        infoTooltipId="number-of-colors-help"
+        infoTooltipText={HELP_TOPICS.numberOfColors.tooltip}
         onRangePointerDown={handlePointerDown}
         onRangeInput={handleKeyboardInput}
         onRangeChange={onNumColorsCommit}
@@ -348,6 +371,9 @@
         step={NUM_PALETTES_RANGE.step}
         bind:value={numPalettes}
         groupHelpText={`Range ${NUM_PALETTES_RANGE.min} to ${NUM_PALETTES_RANGE.max}. Use slider for coarse adjustment and number input for precise adjustment.`}
+        infoButtonLabel="Explain Number of Palettes"
+        infoTooltipId="number-of-palettes-help"
+        infoTooltipText={HELP_TOPICS.numberOfPalettes.tooltip}
         onRangePointerDown={handlePointerDown}
         onRangeInput={handleKeyboardInput}
         onRangeChange={onNumPalettesCommit}
@@ -382,7 +408,14 @@
     <div class="advanced-panel">
       <div class="advanced-body">
         <div class="bezier-section">
-          <div class="bezier-title">Bezier Curve</div>
+          <div class="label-row">
+            <div class="bezier-title">Bezier Curve</div>
+            <HelpTooltip
+              id="bezier-curve-help"
+              label="Explain Bezier Curve"
+              text={HELP_TOPICS.bezierCurve.tooltip}
+            />
+          </div>
           <BezierEditor
             bind:x1
             bind:y1
@@ -432,6 +465,13 @@
     display: grid;
     grid-template-columns: 1fr;
     gap: var(--space-md);
+  }
+
+  .label-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    flex-wrap: wrap;
   }
 
   .base-color-row {

--- a/src/lib/components/ContrastControls.dom.spec.ts
+++ b/src/lib/components/ContrastControls.dom.spec.ts
@@ -57,7 +57,12 @@ describe('ContrastControls', () => {
   it('renders contrast algorithm select and WCAG indicator checklist by default', () => {
     render(ContrastControls);
 
-    expect(screen.getByLabelText(/contrast algorithm/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('Contrast algorithm', { selector: 'select' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /explain contrast algorithm/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /explain swatch contrast indicators/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /explain contrast mode/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/show wcag 3 to 1 indicator/i)).toBeChecked();
     expect(screen.getByLabelText(/show wcag aa indicator/i)).toBeChecked();
     expect(screen.getByLabelText(/show wcag aaa indicator/i)).toBeChecked();
@@ -70,7 +75,7 @@ describe('ContrastControls', () => {
   it('switches indicator checklist when changing algorithm to APCA', async () => {
     render(ContrastControls);
 
-    await fireEvent.change(screen.getByLabelText(/contrast algorithm/i), {
+    await fireEvent.change(screen.getByLabelText('Contrast algorithm', { selector: 'select' }), {
       target: { value: 'APCA' }
     });
 
@@ -101,7 +106,7 @@ describe('ContrastControls', () => {
     await fireEvent.click(screen.getByLabelText(/show wcag 3 to 1 indicator/i));
     await fireEvent.click(screen.getByLabelText(/show wcag aa indicator/i));
     await fireEvent.click(screen.getByLabelText(/show wcag aaa indicator/i));
-    await fireEvent.change(screen.getByLabelText(/contrast algorithm/i), {
+    await fireEvent.change(screen.getByLabelText('Contrast algorithm', { selector: 'select' }), {
       target: { value: 'APCA' }
     });
     await fireEvent.click(screen.getByLabelText(/show apca large indicator/i));
@@ -122,7 +127,9 @@ describe('ContrastControls', () => {
   it('renders auto-mode reference controls', () => {
     render(ContrastControls);
 
-    expect(screen.getByLabelText(/contrast mode/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('Contrast Mode', { selector: 'select' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /explain low reference/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /explain high reference/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /pick low reference/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /pick high reference/i })).toBeInTheDocument();
     expect(
@@ -133,7 +140,7 @@ describe('ContrastControls', () => {
   it('switches to manual mode and shows manual color inputs', async () => {
     render(ContrastControls);
 
-    const modeSelect = screen.getByLabelText(/contrast mode/i);
+    const modeSelect = screen.getByLabelText('Contrast Mode', { selector: 'select' });
     await fireEvent.change(modeSelect, { target: { value: 'manual' } });
 
     expect(get(contrastMode)).toBe('manual');
@@ -144,7 +151,7 @@ describe('ContrastControls', () => {
   it('does not update store when given an invalid manual hex value', async () => {
     render(ContrastControls);
 
-    await fireEvent.change(screen.getByLabelText(/contrast mode/i), {
+    await fireEvent.change(screen.getByLabelText('Contrast Mode', { selector: 'select' }), {
       target: { value: 'manual' }
     });
 

--- a/src/lib/components/ContrastControls.svelte
+++ b/src/lib/components/ContrastControls.svelte
@@ -20,7 +20,9 @@
     resolveGeneratedPaletteNames,
     resolveNeutralPaletteName
   } from '$lib/paletteNameUtils';
+  import { HELP_TOPICS } from '$lib/help/helpContent';
   import CheckboxRow from './CheckboxRow.svelte';
+  import HelpTooltip from './HelpTooltip.svelte';
   import type { ContrastAlgorithm, SwatchContrastIndicators } from '$lib/types';
 
   interface Props {
@@ -55,20 +57,6 @@
         )
       : []
   );
-  const APCA_LEVEL_DESCRIPTIONS = {
-    large:
-      'APCA Lc 45 minimum for larger, heavier text such as headlines, and for icons or pictograms with fine detail.',
-    fluent:
-      'APCA Lc 60 minimum for fluent content text that is not body/column text. This is text users are expected to read.',
-    body: 'APCA Lc 75 minimum for columns of body text where readability is critical. APCA guidance prefers Lc 90 for body text.'
-  } as const;
-  const WCAG_LEVEL_DESCRIPTIONS = {
-    threeToOne:
-      'WCAG 2.2 3:1 threshold used for large text, UI components/graphics, and link color differentiation from surrounding text when color is used.',
-    aa: 'WCAG 2.2 AA text threshold: 4.5:1 for normal-size text.',
-    aaa: 'WCAG 2.2 AAA text threshold: 7:1 for normal-size text.'
-  } as const;
-
   function handleModeChange(event: Event) {
     const target = event.target as HTMLSelectElement;
     const newMode = target.value as 'auto' | 'manual';
@@ -225,7 +213,14 @@
 
 <section class="contrast-controls">
   <div class="field">
-    <label class="label" for="contrast-algorithm">Contrast Algorithm</label>
+    <div class="label-row">
+      <label class="label" for="contrast-algorithm">Contrast Algorithm</label>
+      <HelpTooltip
+        id="contrast-algorithm-help"
+        label="Explain Contrast Algorithm"
+        text={HELP_TOPICS.contrastAlgorithm.tooltip}
+      />
+    </div>
     <select
       class="select"
       id="contrast-algorithm"
@@ -239,7 +234,14 @@
   </div>
 
   <div class="field">
-    <span class="label">Swatch Contrast Indicators</span>
+    <div class="label-row">
+      <span class="label">Swatch Contrast Indicators</span>
+      <HelpTooltip
+        id="indicator-levels-help"
+        label="Explain Swatch Contrast Indicators"
+        text={HELP_TOPICS.indicatorLevels.tooltip}
+      />
+    </div>
     <div class="checklist" role="group" aria-label="Swatch contrast indicators">
       {#if contrastAlgorithmLocal === 'WCAG'}
         <CheckboxRow
@@ -248,7 +250,7 @@
           checked={swatchContrastIndicatorsLocal.wcagThreeToOne}
           ariaLabel="Show WCAG 3 to 1 indicator"
           helpLabel="Explain WCAG 3 to 1 level"
-          helpText={WCAG_LEVEL_DESCRIPTIONS.threeToOne}
+          helpText={HELP_TOPICS.wcagThreeToOne.tooltip}
           onChange={(checked) => handleIndicatorToggle('wcagThreeToOne', checked)}
         />
         <CheckboxRow
@@ -257,7 +259,7 @@
           checked={swatchContrastIndicatorsLocal.wcagAA}
           ariaLabel="Show WCAG AA indicator"
           helpLabel="Explain WCAG AA level"
-          helpText={WCAG_LEVEL_DESCRIPTIONS.aa}
+          helpText={HELP_TOPICS.wcagAA.tooltip}
           onChange={(checked) => handleIndicatorToggle('wcagAA', checked)}
         />
         <CheckboxRow
@@ -266,7 +268,7 @@
           checked={swatchContrastIndicatorsLocal.wcagAAA}
           ariaLabel="Show WCAG AAA indicator"
           helpLabel="Explain WCAG AAA level"
-          helpText={WCAG_LEVEL_DESCRIPTIONS.aaa}
+          helpText={HELP_TOPICS.wcagAAA.tooltip}
           onChange={(checked) => handleIndicatorToggle('wcagAAA', checked)}
         />
       {:else}
@@ -276,7 +278,7 @@
           checked={swatchContrastIndicatorsLocal.apcaLarge}
           ariaLabel="Show APCA Large indicator"
           helpLabel="Explain APCA Large level"
-          helpText={APCA_LEVEL_DESCRIPTIONS.large}
+          helpText={HELP_TOPICS.apcaLarge.tooltip}
           onChange={(checked) => handleIndicatorToggle('apcaLarge', checked)}
         />
         <CheckboxRow
@@ -285,7 +287,7 @@
           checked={swatchContrastIndicatorsLocal.apcaFluent}
           ariaLabel="Show APCA Fluent indicator"
           helpLabel="Explain APCA Fluent level"
-          helpText={APCA_LEVEL_DESCRIPTIONS.fluent}
+          helpText={HELP_TOPICS.apcaFluent.tooltip}
           onChange={(checked) => handleIndicatorToggle('apcaFluent', checked)}
         />
         <CheckboxRow
@@ -294,7 +296,7 @@
           checked={swatchContrastIndicatorsLocal.apcaBody}
           ariaLabel="Show APCA Body indicator"
           helpLabel="Explain APCA Body level"
-          helpText={APCA_LEVEL_DESCRIPTIONS.body}
+          helpText={HELP_TOPICS.apcaBody.tooltip}
           onChange={(checked) => handleIndicatorToggle('apcaBody', checked)}
         />
       {/if}
@@ -302,7 +304,14 @@
   </div>
 
   <div class="field">
-    <label class="label" for="contrast-mode">Contrast Mode</label>
+    <div class="label-row">
+      <label class="label" for="contrast-mode">Contrast Mode</label>
+      <HelpTooltip
+        id="contrast-mode-help"
+        label="Explain Contrast Mode"
+        text={HELP_TOPICS.contrastMode.tooltip}
+      />
+    </div>
     <select class="select" id="contrast-mode" value={contrastModeLocal} onchange={handleModeChange}>
       <option value="auto">Auto</option>
       <option value="manual">Manual</option>
@@ -312,7 +321,14 @@
   {#if contrastModeLocal === 'manual'}
     <div class="manual-controls">
       <div class="field">
-        <label class="label" for="contrast-low">Low Contrast Color</label>
+        <div class="label-row">
+          <label class="label" for="contrast-low">Low Contrast Color</label>
+          <HelpTooltip
+            id="low-reference-help"
+            label="Explain Low Reference"
+            text={HELP_TOPICS.lowReference.tooltip}
+          />
+        </div>
         <div class="color-input-group">
           <input
             id="contrast-low"
@@ -334,7 +350,14 @@
       </div>
 
       <div class="field">
-        <label class="label" for="contrast-high">High Contrast Color</label>
+        <div class="label-row">
+          <label class="label" for="contrast-high">High Contrast Color</label>
+          <HelpTooltip
+            id="high-reference-help"
+            label="Explain High Reference"
+            text={HELP_TOPICS.highReference.tooltip}
+          />
+        </div>
         <div class="color-input-group">
           <input
             id="contrast-high"
@@ -358,7 +381,14 @@
   {:else}
     <div class="auto-controls">
       <div class="field">
-        <span class="label">Low Reference</span>
+        <div class="label-row">
+          <span class="label">Low Reference</span>
+          <HelpTooltip
+            id="low-reference-help"
+            label="Explain Low Reference"
+            text={HELP_TOPICS.lowReference.tooltip}
+          />
+        </div>
         <div class="reference-row">
           <div class="reference-chip" class:reference-chip--invalid={!lowReferenceSummary.valid}>
             <span
@@ -375,7 +405,14 @@
       </div>
 
       <div class="field">
-        <span class="label">High Reference</span>
+        <div class="label-row">
+          <span class="label">High Reference</span>
+          <HelpTooltip
+            id="high-reference-help"
+            label="Explain High Reference"
+            text={HELP_TOPICS.highReference.tooltip}
+          />
+        </div>
         <div class="reference-row">
           <div class="reference-chip" class:reference-chip--invalid={!highReferenceSummary.valid}>
             <span
@@ -411,6 +448,13 @@
     display: grid;
     gap: var(--space-xs);
     padding: var(--space-xs) 0;
+  }
+
+  .label-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    flex-wrap: wrap;
   }
 
   .color-input-group {

--- a/src/lib/components/DisplaySettings.dom.spec.ts
+++ b/src/lib/components/DisplaySettings.dom.spec.ts
@@ -48,6 +48,7 @@ describe('DisplaySettings', () => {
     const advancedSummary = getAdvancedSummary();
 
     expect(screen.getByLabelText('Display color space format')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explain Color Space' })).toBeInTheDocument();
     expect(screen.getByLabelText('Theme preference')).toBeInTheDocument();
     expect(screen.getByLabelText('Show step labels on swatches')).toBeInTheDocument();
     expect(screen.getByLabelText('Show value labels on swatches')).toBeInTheDocument();
@@ -64,6 +65,8 @@ describe('DisplaySettings', () => {
 
     await user.click(getAdvancedSummary());
     expect(screen.getByLabelText('Gamut mapping target')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explain Gamut Mapping' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explain Gamut Warnings' })).toBeInTheDocument();
 
     await user.selectOptions(screen.getByLabelText('Display color space format'), 'oklch');
 

--- a/src/lib/components/DisplaySettings.svelte
+++ b/src/lib/components/DisplaySettings.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { HELP_TOPICS } from '$lib/help/helpContent';
   import Icon from './Icon.svelte';
   import CheckboxRow from './CheckboxRow.svelte';
+  import HelpTooltip from './HelpTooltip.svelte';
   import {
     displayColorSpace,
     oklchDisplaySignificantDigits,
@@ -141,7 +143,14 @@
 <section class="display-settings" data-testid="display-settings">
   <section class="control-subsection">
     <div class="field">
-      <label class="label" for="display-color-space">Color Space</label>
+      <div class="label-row">
+        <label class="label" for="display-color-space">Color Space</label>
+        <HelpTooltip
+          id="color-space-help"
+          label="Explain Color Space"
+          text={HELP_TOPICS.colorSpace.tooltip}
+        />
+      </div>
       <select
         class="select"
         id="display-color-space"
@@ -228,7 +237,7 @@
             groupHelpText="Use slider for coarse adjustment and number input for precise adjustment."
             infoButtonLabel="Explain OKLCH significant digits"
             infoTooltipId="oklch-significant-digits-help"
-            infoTooltipText="Controls how many significant digits OKLCH swatches use for rendering and labels."
+            infoTooltipText={HELP_TOPICS.oklchPrecision.tooltip}
             onRangeInput={handleOklchSignificantDigitsInput}
             onRangeChange={handleOklchSignificantDigitsChange}
             onNumberInput={handleOklchSignificantDigitsInput}
@@ -237,7 +246,14 @@
         {/if}
 
         <div class="field">
-          <label class="label" for="gamut-space">Gamut Mapping</label>
+          <div class="label-row">
+            <label class="label" for="gamut-space">Gamut Mapping</label>
+            <HelpTooltip
+              id="gamut-mapping-help"
+              label="Explain Gamut Mapping"
+              text={HELP_TOPICS.gamutMapping.tooltip}
+            />
+          </div>
           <select
             class="select"
             id="gamut-space"
@@ -259,12 +275,21 @@
         </div>
 
         <div class="field">
-          <span class="label">Gamut Warnings</span>
+          <div class="label-row">
+            <span class="label">Gamut Warnings</span>
+            <HelpTooltip
+              id="gamut-warnings-help"
+              label="Explain Gamut Warnings"
+              text={HELP_TOPICS.gamutWarnings.tooltip}
+            />
+          </div>
           <CheckboxRow
             id="show-swatch-gamut-warnings"
             label="Show warnings on gamut-mapped swatches"
             checked={showSwatchGamutWarningsLocal}
             ariaLabel="Show gamut warnings on mapped swatches"
+            helpLabel="Explain gamut-mapped swatch warnings"
+            helpText={HELP_TOPICS.gamutWarnings.tooltip}
             onChange={handleSwatchGamutWarningsToggle}
           />
         </div>
@@ -312,6 +337,13 @@
     display: grid;
     gap: var(--space-xs);
     padding: var(--space-xs) 0;
+  }
+
+  .label-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    flex-wrap: wrap;
   }
 
   .advanced-group {

--- a/src/lib/components/ExportButtons.dom.spec.ts
+++ b/src/lib/components/ExportButtons.dom.spec.ts
@@ -26,6 +26,7 @@ describe('ExportButtons', () => {
   it('disables export actions when there are no colors', () => {
     render(ExportButtons, { props: { neutrals: [], palettes: [] } });
 
+    expect(screen.getByRole('button', { name: /explain export format/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /export json design tokens/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: /export css custom properties/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: /export scss variables/i })).toBeDisabled();

--- a/src/lib/components/ExportButtons.svelte
+++ b/src/lib/components/ExportButtons.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
+  import { HELP_TOPICS } from '$lib/help/helpContent';
   import { downloadDesignTokens, downloadCSS, downloadSCSS } from '$lib/exportUtils';
   import { copyToClipboard } from '$lib/colorUtils';
   import { announce } from '$lib/announce';
   import Button from './Button.svelte';
+  import HelpTooltip from './HelpTooltip.svelte';
   import Icon from './Icon.svelte';
 
   interface Props {
@@ -78,6 +80,14 @@
 </script>
 
 <div class="export-buttons">
+  <div class="label-row">
+    <span class="label">Export Format</span>
+    <HelpTooltip
+      id="export-format-help"
+      label="Explain Export Format"
+      text={HELP_TOPICS.exportFormat.tooltip}
+    />
+  </div>
   <Button
     onclick={shareURL}
     ariaLabel={copyConfirmed ? 'URL copied to clipboard' : 'Copy shareable URL to clipboard'}
@@ -117,6 +127,13 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-sm);
+  }
+
+  .label-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    flex-wrap: wrap;
   }
 
   .label-enter {

--- a/src/lib/components/GettingStartedCallout.dom.spec.ts
+++ b/src/lib/components/GettingStartedCallout.dom.spec.ts
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { GETTING_STARTED_CALLOUT_STORAGE_KEY } from '$lib/help/helpContent';
+import { closeGettingStartedGuide } from '$lib/help/helpDialogStore';
+import GettingStartedCallout from './GettingStartedCallout.svelte';
+import GettingStartedDialog from './GettingStartedDialog.svelte';
+
+describe('GettingStartedCallout', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    closeGettingStartedGuide();
+  });
+
+  it('renders when not dismissed', async () => {
+    render(GettingStartedCallout);
+
+    expect(await screen.findByTestId('getting-started-callout')).toBeInTheDocument();
+  });
+
+  it('opens the Getting Started guide', async () => {
+    const user = userEvent.setup();
+    render(GettingStartedCallout);
+    render(GettingStartedDialog);
+
+    await user.click(await screen.findByRole('button', { name: 'Getting Started' }));
+
+    expect(await screen.findByRole('dialog', { name: /getting started/i })).toBeInTheDocument();
+  });
+
+  it('dismisses and persists dismissal in localStorage', async () => {
+    const user = userEvent.setup();
+    render(GettingStartedCallout);
+
+    await user.click(await screen.findByRole('button', { name: 'Dismiss' }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('getting-started-callout')).not.toBeInTheDocument();
+    });
+    expect(window.localStorage.getItem(GETTING_STARTED_CALLOUT_STORAGE_KEY)).toBe('true');
+  });
+
+  it('remains hidden after dismissal', async () => {
+    window.localStorage.setItem(GETTING_STARTED_CALLOUT_STORAGE_KEY, 'true');
+
+    render(GettingStartedCallout);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('getting-started-callout')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/lib/components/GettingStartedCallout.svelte
+++ b/src/lib/components/GettingStartedCallout.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { GETTING_STARTED_CALLOUT_STORAGE_KEY, HELP_TOPICS } from '$lib/help/helpContent';
+  import { openGettingStartedGuide } from '$lib/help/helpDialogStore';
+
+  let ready = $state(false);
+  let dismissed = $state(true);
+
+  onMount(() => {
+    try {
+      dismissed = window.localStorage.getItem(GETTING_STARTED_CALLOUT_STORAGE_KEY) === 'true';
+    } catch {
+      dismissed = false;
+    }
+    ready = true;
+  });
+
+  function openGuide(event: MouseEvent): void {
+    openGettingStartedGuide(event.currentTarget as HTMLElement);
+  }
+
+  function dismissCallout(): void {
+    dismissed = true;
+    try {
+      window.localStorage.setItem(GETTING_STARTED_CALLOUT_STORAGE_KEY, 'true');
+    } catch {
+      // Ignore unavailable storage; dismissal still applies for this session.
+    }
+  }
+</script>
+
+{#if ready && !dismissed}
+  <section
+    class="getting-started-callout"
+    aria-labelledby="getting-started-callout-title"
+    data-testid="getting-started-callout"
+  >
+    <div class="callout-copy">
+      <h2 id="getting-started-callout-title">New to Chroma11y?</h2>
+      <p>
+        Learn how {HELP_TOPICS.oklch.label}, curves, warmth, saturation, and contrast checks work
+        together.
+      </p>
+    </div>
+    <div class="callout-actions">
+      <button type="button" class="callout-primary" onclick={openGuide}>Getting Started</button>
+      <button type="button" class="callout-secondary" onclick={dismissCallout}>Dismiss</button>
+    </div>
+  </section>
+{/if}
+
+<style>
+  .getting-started-callout {
+    display: grid;
+    gap: var(--space-md);
+    padding: var(--space-md);
+    border: var(--border-width-thin) solid color-mix(in oklab, var(--accent) 35%, var(--border));
+    border-radius: var(--radius-md);
+    background: color-mix(in oklab, var(--accent) 8%, var(--bg-primary));
+    color: var(--text-primary);
+  }
+
+  .callout-copy {
+    display: grid;
+    gap: var(--space-xs);
+  }
+
+  .callout-copy h2,
+  .callout-copy p {
+    margin: 0;
+  }
+
+  .callout-copy h2 {
+    font-size: var(--font-size-md);
+    line-height: var(--line-height-tight);
+    letter-spacing: var(--letter-spacing-normal);
+  }
+
+  .callout-copy p {
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-normal);
+  }
+
+  .callout-actions {
+    display: flex;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+  }
+
+  .callout-primary,
+  .callout-secondary {
+    min-height: var(--touch-target-comfortable);
+    padding: var(--space-sm) var(--space-md);
+    border-radius: var(--radius-md);
+    font: inherit;
+    font-weight: var(--font-weight-semibold);
+    cursor: pointer;
+  }
+
+  .callout-primary {
+    border: var(--border-width-thin) solid color-mix(in oklab, var(--accent) 70%, black);
+    background: color-mix(in oklab, var(--accent) 90%, black);
+    color: white;
+  }
+
+  .callout-secondary {
+    border: var(--border-width-thin) solid var(--border);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+  }
+</style>

--- a/src/lib/components/GettingStartedDialog.dom.spec.ts
+++ b/src/lib/components/GettingStartedDialog.dom.spec.ts
@@ -1,0 +1,98 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { HELP_RESOURCES } from '$lib/help/helpContent';
+import { closeGettingStartedGuide, gettingStartedDialog } from '$lib/help/helpDialogStore';
+import AppHeader from './AppHeader.svelte';
+import GettingStartedDialog from './GettingStartedDialog.svelte';
+
+describe('GettingStartedDialog', () => {
+  beforeEach(() => {
+    closeGettingStartedGuide();
+  });
+
+  it('opens from the header Help trigger with an accessible dialog name', async () => {
+    const user = userEvent.setup();
+    render(AppHeader);
+    render(GettingStartedDialog);
+
+    await user.click(screen.getByRole('button', { name: /open getting started guide/i }));
+
+    expect(await screen.findByRole('dialog', { name: /getting started/i })).toBeInTheDocument();
+  });
+
+  it('includes core help topics and external resource links', async () => {
+    const user = userEvent.setup();
+    render(AppHeader);
+    render(GettingStartedDialog);
+
+    await user.click(screen.getByRole('button', { name: /open getting started guide/i }));
+
+    await screen.findByRole('dialog', { name: /getting started/i });
+
+    expect(screen.getAllByText(/OKLCH/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Bezier/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/WCAG/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/APCA/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/warmth/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/saturation/i).length).toBeGreaterThan(0);
+
+    for (const resource of HELP_RESOURCES) {
+      const link = screen.getByRole('link', { name: resource.title });
+      expect(link).toHaveAttribute('href', resource.url);
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noreferrer');
+    }
+  });
+
+  it('closes with the visible close button and returns focus to the opener', async () => {
+    const user = userEvent.setup();
+    render(AppHeader);
+    render(GettingStartedDialog);
+
+    const opener = screen.getByRole('button', { name: /open getting started guide/i });
+    await user.click(opener);
+    await screen.findByRole('dialog', { name: /getting started/i });
+
+    await user.click(screen.getByRole('button', { name: /close getting started guide/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /getting started/i })).not.toBeInTheDocument();
+    });
+    expect(opener).toHaveFocus();
+  });
+
+  it('closes with Escape and returns focus to the opener', async () => {
+    const user = userEvent.setup();
+    render(AppHeader);
+    render(GettingStartedDialog);
+
+    const opener = screen.getByRole('button', { name: /open getting started guide/i });
+    await user.click(opener);
+    await screen.findByRole('dialog', { name: /getting started/i });
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /getting started/i })).not.toBeInTheDocument();
+    });
+    expect(opener).toHaveFocus();
+  });
+
+  it('updates shared dialog state when closed', async () => {
+    const user = userEvent.setup();
+    render(AppHeader);
+    render(GettingStartedDialog);
+
+    await user.click(screen.getByRole('button', { name: /open getting started guide/i }));
+    expect(await screen.findByRole('dialog', { name: /getting started/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /close getting started guide/i }));
+
+    await waitFor(() => {
+      expect(get(gettingStartedDialog).open).toBe(false);
+    });
+  });
+});

--- a/src/lib/components/GettingStartedDialog.svelte
+++ b/src/lib/components/GettingStartedDialog.svelte
@@ -1,0 +1,315 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+  import { GETTING_STARTED_SECTIONS, HELP_RESOURCES, HELP_TOPICS } from '$lib/help/helpContent';
+  import { closeGettingStartedGuide, gettingStartedDialog } from '$lib/help/helpDialogStore';
+  import Icon from './Icon.svelte';
+
+  const dialogId = 'getting-started-dialog';
+  const titleId = 'getting-started-dialog-title';
+  const introId = 'getting-started-dialog-intro';
+  const focusableSelector = [
+    'button:not(:disabled)',
+    '[href]',
+    'input:not(:disabled)',
+    'select:not(:disabled)',
+    'textarea:not(:disabled)',
+    '[tabindex]:not([tabindex="-1"])'
+  ].join(', ');
+
+  let dialogEl: HTMLElement | undefined = $state();
+  let closeButtonEl: HTMLButtonElement | undefined = $state();
+  let open = $derived($gettingStartedDialog.open);
+  let opener = $derived($gettingStartedDialog.opener);
+
+  async function focusInitialElement(): Promise<void> {
+    await tick();
+    closeButtonEl?.focus({ preventScroll: true });
+  }
+
+  $effect(() => {
+    if (open) {
+      void focusInitialElement();
+    }
+  });
+
+  async function closeDialog(): Promise<void> {
+    const returnTarget = opener;
+    closeGettingStartedGuide();
+    await tick();
+
+    if (returnTarget?.isConnected) {
+      returnTarget.focus({ preventScroll: true });
+    }
+  }
+
+  function getFocusableElements(): HTMLElement[] {
+    if (!dialogEl) return [];
+    return Array.from(dialogEl.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+      (element) => !element.hasAttribute('hidden')
+    );
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (!open) return;
+    if (event.defaultPrevented) return;
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      void closeDialog();
+      return;
+    }
+
+    if (event.key !== 'Tab') return;
+
+    const focusable = getFocusableElements();
+    if (focusable.length === 0) {
+      event.preventDefault();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const activeElement = document.activeElement;
+
+    if (!activeElement || !dialogEl?.contains(activeElement)) {
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus();
+      return;
+    }
+
+    const activeIndex = focusable.indexOf(activeElement as HTMLElement);
+    const nextIndex = event.shiftKey
+      ? activeIndex <= 0
+        ? focusable.length - 1
+        : activeIndex - 1
+      : activeIndex === -1 || activeIndex === focusable.length - 1
+        ? 0
+        : activeIndex + 1;
+
+    event.preventDefault();
+    focusable[nextIndex].focus();
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open}
+  <div class="dialog-layer">
+    <div class="dialog-backdrop" aria-hidden="true"></div>
+    <div
+      id={dialogId}
+      class="getting-started-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={introId}
+      tabindex="-1"
+      bind:this={dialogEl}
+    >
+      <div class="dialog-header">
+        <div class="dialog-heading">
+          <p class="eyebrow">Help</p>
+          <h2 id={titleId}>Getting Started</h2>
+        </div>
+        <button
+          bind:this={closeButtonEl}
+          type="button"
+          class="dialog-close"
+          aria-label="Close Getting Started guide"
+          onclick={() => void closeDialog()}
+        >
+          <Icon name="close" size="var(--icon-size-dialog-close)" />
+          <span>Close</span>
+        </button>
+      </div>
+
+      <div class="dialog-body">
+        <p id={introId} class="intro">
+          Use this guide to connect the main controls to accessible palette decisions.
+        </p>
+
+        <div class="guide-grid">
+          {#each GETTING_STARTED_SECTIONS as section (section.id)}
+            <section class="guide-section" aria-labelledby={`getting-started-${section.id}`}>
+              <h3 id={`getting-started-${section.id}`}>{section.title}</h3>
+              {#each section.body as paragraph (paragraph)}
+                <p>{paragraph}</p>
+              {/each}
+            </section>
+          {/each}
+        </div>
+
+        <section class="guide-section resources" aria-labelledby="getting-started-resources">
+          <h3 id="getting-started-resources">Learn More</h3>
+          <p>
+            These resources cover {HELP_TOPICS.oklch.label}, {HELP_TOPICS.wcag.label}, and
+            {HELP_TOPICS.apca.label} in more depth.
+          </p>
+          <ul class="resource-list">
+            {#each HELP_RESOURCES as resource (resource.url)}
+              <li>
+                <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+                <a href={resource.url} target="_blank" rel="noreferrer">{resource.title}</a>
+                <span>{resource.description}</span>
+              </li>
+            {/each}
+          </ul>
+        </section>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .dialog-layer {
+    position: fixed;
+    inset: 0;
+    z-index: 80;
+    display: grid;
+    place-items: center;
+    padding: var(--space-lg);
+  }
+
+  .dialog-backdrop {
+    position: absolute;
+    inset: 0;
+    background: color-mix(in oklab, black 42%, transparent);
+  }
+
+  .getting-started-dialog {
+    position: relative;
+    z-index: 1;
+    inline-size: min(48rem, 100%);
+    max-block-size: min(44rem, calc(100vh - var(--space-xl)));
+    display: grid;
+    grid-template-rows: auto 1fr;
+    overflow: hidden;
+    border: var(--border-width-thin) solid var(--border);
+    border-radius: var(--radius-lg);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    box-shadow: 0 var(--space-lg) var(--space-xl) color-mix(in oklab, black 24%, transparent);
+  }
+
+  .dialog-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-md);
+    padding: var(--space-lg);
+    border-bottom: var(--border-width-thin) solid
+      color-mix(in oklab, var(--border) 60%, transparent);
+  }
+
+  .dialog-heading {
+    display: grid;
+    gap: var(--space-xs);
+  }
+
+  .eyebrow,
+  .dialog-heading h2,
+  .guide-section h3,
+  .intro,
+  .guide-section p {
+    margin: 0;
+  }
+
+  .eyebrow {
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .dialog-heading h2 {
+    font-size: var(--font-size-xl);
+    line-height: var(--line-height-tight);
+    letter-spacing: var(--letter-spacing-normal);
+  }
+
+  .dialog-close {
+    min-height: var(--touch-target-comfortable);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-sm) var(--space-md);
+    border: var(--border-width-thin) solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    font: inherit;
+    font-weight: var(--font-weight-semibold);
+    cursor: pointer;
+  }
+
+  .dialog-body {
+    display: grid;
+    gap: var(--space-lg);
+    overflow: auto;
+    padding: var(--space-lg);
+  }
+
+  .intro {
+    color: var(--text-secondary);
+    font-size: var(--font-size-md);
+  }
+
+  .guide-grid {
+    display: grid;
+    gap: var(--space-md);
+  }
+
+  .guide-section {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .guide-section h3 {
+    font-size: var(--font-size-lg);
+    line-height: var(--line-height-tight);
+    letter-spacing: var(--letter-spacing-normal);
+  }
+
+  .guide-section p,
+  .resource-list {
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-normal);
+  }
+
+  .resource-list {
+    display: grid;
+    gap: var(--space-sm);
+    margin: 0;
+    padding-inline-start: var(--space-lg);
+  }
+
+  .resource-list li {
+    display: grid;
+    gap: var(--space-2xs);
+  }
+
+  .resource-list a {
+    color: var(--accent);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  @media (max-width: 640px) {
+    .dialog-layer {
+      align-items: end;
+      padding: var(--space-sm);
+    }
+
+    .getting-started-dialog {
+      max-block-size: calc(100vh - var(--space-lg));
+    }
+
+    .dialog-header {
+      flex-direction: column;
+    }
+
+    .dialog-close {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+</style>

--- a/src/lib/components/HelpTooltip.dom.spec.ts
+++ b/src/lib/components/HelpTooltip.dom.spec.ts
@@ -1,0 +1,307 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import HelpTooltip from './HelpTooltip.svelte';
+
+const DEFAULT_VIEWPORT_WIDTH = window.innerWidth;
+const DEFAULT_VIEWPORT_HEIGHT = window.innerHeight;
+
+interface RectInit {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function createRect({ x, y, width, height }: RectInit): DOMRect {
+  return {
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    left: x,
+    right: x + width,
+    bottom: y + height,
+    toJSON: () => undefined
+  } as DOMRect;
+}
+
+function mockElementRect(element: Element, rect: RectInit): void {
+  vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(createRect(rect));
+
+  Object.defineProperties(element, {
+    offsetWidth: {
+      configurable: true,
+      value: rect.width
+    },
+    offsetHeight: {
+      configurable: true,
+      value: rect.height
+    },
+    clientWidth: {
+      configurable: true,
+      value: rect.width
+    },
+    clientHeight: {
+      configurable: true,
+      value: rect.height
+    }
+  });
+}
+
+function setViewportSize(width: number, height: number): void {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    value: width
+  });
+
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    value: height
+  });
+
+  Object.defineProperty(document.documentElement, 'clientWidth', {
+    configurable: true,
+    value: width
+  });
+
+  Object.defineProperty(document.documentElement, 'clientHeight', {
+    configurable: true,
+    value: height
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    value: DEFAULT_VIEWPORT_WIDTH
+  });
+
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    value: DEFAULT_VIEWPORT_HEIGHT
+  });
+
+  Object.defineProperty(document.documentElement, 'clientWidth', {
+    configurable: true,
+    value: DEFAULT_VIEWPORT_WIDTH
+  });
+
+  Object.defineProperty(document.documentElement, 'clientHeight', {
+    configurable: true,
+    value: DEFAULT_VIEWPORT_HEIGHT
+  });
+});
+
+describe('HelpTooltip', () => {
+  it('renders an accessible trigger associated with tooltip content', () => {
+    render(HelpTooltip, {
+      props: {
+        id: 'test-help',
+        label: 'Explain test control',
+        text: 'Short explanatory help text.'
+      }
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Explain test control' });
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
+
+    expect(trigger).toHaveAttribute('aria-describedby', 'test-help');
+    expect(tooltip).toHaveAttribute('id', 'test-help');
+  });
+
+  it('opens on focus and closes on blur', async () => {
+    render(HelpTooltip, {
+      props: {
+        id: 'focus-help',
+        label: 'Explain focus control',
+        text: 'Focus help text.'
+      }
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Explain focus control' });
+
+    await fireEvent.focus(trigger);
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeVisible();
+    });
+
+    await fireEvent.blur(trigger);
+    expect(screen.getByRole('tooltip', { hidden: true })).toHaveAttribute('hidden');
+  });
+
+  it('opens on pointer hover and closes on pointer leave', async () => {
+    render(HelpTooltip, {
+      props: {
+        id: 'hover-help',
+        label: 'Explain hover control',
+        text: 'Hover help text.'
+      }
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Explain hover control' });
+
+    await fireEvent.pointerEnter(trigger);
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeVisible();
+    });
+
+    await fireEvent.pointerLeave(trigger);
+    expect(screen.getByRole('tooltip', { hidden: true })).toHaveAttribute('hidden');
+  });
+
+  it('closes on Escape', async () => {
+    render(HelpTooltip, {
+      props: {
+        id: 'escape-help',
+        label: 'Explain escape control',
+        text: 'Escape help text.'
+      }
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Explain escape control' });
+    await fireEvent.focus(trigger);
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeVisible();
+    });
+
+    await fireEvent.keyDown(trigger, { key: 'Escape' });
+
+    expect(screen.getByRole('tooltip', { hidden: true })).toHaveAttribute('hidden');
+  });
+
+  it('keeps tooltip content non-interactive', async () => {
+    render(HelpTooltip, {
+      props: {
+        id: 'plain-help',
+        label: 'Explain plain control',
+        text: 'Plain text only.'
+      }
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Explain plain control' });
+    await fireEvent.focus(trigger);
+    const tooltip = screen.getByRole('tooltip');
+    const focusable = within(tooltip).queryAllByRole('button');
+
+    expect(focusable).toHaveLength(0);
+    expect(
+      tooltip.querySelectorAll('a, input, select, textarea, [tabindex]:not([tabindex="-1"])')
+    ).toHaveLength(0);
+  });
+
+  it('keeps a left-edge tooltip inside the viewport', async () => {
+    setViewportSize(320, 240);
+
+    render(HelpTooltip, {
+      props: {
+        id: 'left-edge-help',
+        label: 'Explain left edge control',
+        text: 'Left edge help text.'
+      }
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Explain left edge control' });
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
+
+    mockElementRect(trigger, {
+      x: 0,
+      y: 96,
+      width: 24,
+      height: 24
+    });
+
+    mockElementRect(tooltip, {
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 44
+    });
+
+    await fireEvent.focus(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeVisible();
+      expect(Number.parseFloat(tooltip.style.left)).toBeGreaterThanOrEqual(8);
+      expect(Number.parseFloat(tooltip.style.left) + 200).toBeLessThanOrEqual(320);
+    });
+  });
+
+  it('keeps a right-edge tooltip inside the viewport', async () => {
+    setViewportSize(320, 240);
+
+    render(HelpTooltip, {
+      props: {
+        id: 'right-edge-help',
+        label: 'Explain right edge control',
+        text: 'Right edge help text.'
+      }
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Explain right edge control' });
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
+
+    mockElementRect(trigger, {
+      x: 296,
+      y: 96,
+      width: 24,
+      height: 24
+    });
+
+    mockElementRect(tooltip, {
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 44
+    });
+
+    await fireEvent.focus(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeVisible();
+      const left = Number.parseFloat(tooltip.style.left);
+
+      expect(left).toBeGreaterThanOrEqual(8);
+      expect(left + 200).toBeLessThanOrEqual(320);
+    });
+  });
+
+  it('flips below the trigger when there is not enough room above', async () => {
+    setViewportSize(320, 120);
+
+    render(HelpTooltip, {
+      props: {
+        id: 'flip-help',
+        label: 'Explain flip control',
+        text: 'Flip help text.'
+      }
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Explain flip control' });
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
+
+    mockElementRect(trigger, {
+      x: 48,
+      y: 10,
+      width: 24,
+      height: 24
+    });
+
+    mockElementRect(tooltip, {
+      x: 0,
+      y: 0,
+      width: 180,
+      height: 44
+    });
+
+    await fireEvent.focus(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeVisible();
+      expect(Number.parseFloat(tooltip.style.top)).toBeGreaterThan(34);
+    });
+  });
+});

--- a/src/lib/components/HelpTooltip.svelte
+++ b/src/lib/components/HelpTooltip.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+  import { autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
+
+  import Icon from './Icon.svelte';
+
+  interface Props {
+    id: string;
+    label: string;
+    text: string;
+    align?: 'start' | 'end';
+    disabled?: boolean;
+  }
+
+  // Floating UI needs numeric values for middleware. These fallbacks mirror the
+  // minimum spacing tokens used by the design system and keep the math stable in jsdom.
+  const HELP_TOOLTIP_OFFSET_PX = 4;
+  const HELP_TOOLTIP_VIEWPORT_PADDING_PX = 8;
+
+  let { id, label, text, align = 'start', disabled = false }: Props = $props();
+  let open = $state(false);
+  let triggerElement: HTMLButtonElement | null = null;
+  let tooltipElement: HTMLSpanElement | null = null;
+  let tooltipX = $state(0);
+  let tooltipY = $state(0);
+  const alignEnd = $derived(align === 'end');
+  const placement = $derived(alignEnd ? 'top-end' : 'top-start');
+
+  function show(): void {
+    if (!disabled) {
+      open = true;
+    }
+  }
+
+  function hide(): void {
+    open = false;
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      hide();
+    }
+  }
+
+  $effect(() => {
+    if (!open || !triggerElement || !tooltipElement) {
+      return;
+    }
+
+    const referenceElement = triggerElement;
+    const floatingElement = tooltipElement;
+    let cancelled = false;
+
+    const updateTooltipPosition = async (): Promise<void> => {
+      const { x, y } = await computePosition(referenceElement, floatingElement, {
+        placement,
+        strategy: 'fixed',
+        middleware: [
+          offset(HELP_TOOLTIP_OFFSET_PX),
+          flip({ padding: HELP_TOOLTIP_VIEWPORT_PADDING_PX }),
+          shift({
+            padding: HELP_TOOLTIP_VIEWPORT_PADDING_PX,
+            crossAxis: true
+          })
+        ]
+      });
+
+      if (!cancelled) {
+        tooltipX = x;
+        tooltipY = y;
+      }
+    };
+
+    void updateTooltipPosition();
+
+    const stopAutoUpdate = autoUpdate(referenceElement, floatingElement, () => {
+      void updateTooltipPosition();
+    });
+
+    return () => {
+      cancelled = true;
+      stopAutoUpdate();
+    };
+  });
+</script>
+
+<span class="help-tooltip-wrapper">
+  <button
+    type="button"
+    class="help-tooltip-trigger"
+    bind:this={triggerElement}
+    aria-label={label}
+    aria-describedby={id}
+    onpointerenter={show}
+    onpointerleave={hide}
+    onfocus={show}
+    onblur={hide}
+    onkeydown={handleKeydown}
+    {disabled}
+  >
+    <Icon name="help" size="var(--icon-size-help)" stroke="var(--icon-stroke-help)" />
+  </button>
+  <span
+    {id}
+    bind:this={tooltipElement}
+    class="help-tooltip"
+    class:help-tooltip--open={open}
+    role="tooltip"
+    hidden={!open}
+    style:left={`${tooltipX}px`}
+    style:top={`${tooltipY}px`}
+  >
+    {text}
+  </span>
+</span>
+
+<style>
+  .help-tooltip-wrapper {
+    --help-tooltip-inline-size: min(36ch, calc(100vw - var(--space-xl)));
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+  }
+
+  .help-tooltip-trigger {
+    width: var(--touch-target-min);
+    min-width: var(--touch-target-min);
+    height: var(--touch-target-min);
+    border-radius: var(--radius-full);
+    border: var(--border-width-thin) solid var(--border);
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    cursor: help;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    transition:
+      border-color var(--transition-fast),
+      color var(--transition-fast),
+      background-color var(--transition-fast);
+  }
+
+  .help-tooltip-trigger:hover:not(:disabled),
+  .help-tooltip-trigger:focus-visible {
+    color: var(--text-primary);
+    border-color: color-mix(in oklab, var(--border) 45%, var(--accent));
+  }
+
+  .help-tooltip-trigger:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .help-tooltip {
+    position: fixed;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+    z-index: 30;
+    inline-size: var(--help-tooltip-inline-size);
+    padding: var(--space-sm) var(--space-md);
+    border-radius: var(--radius-md);
+    border: var(--border-width-thin) solid var(--border);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-normal);
+    box-shadow: 0 var(--space-sm) var(--space-lg) color-mix(in oklab, black 16%, transparent);
+    opacity: 0;
+    transform: translateY(calc(var(--space-2xs) * -1));
+    pointer-events: none;
+    transition:
+      opacity var(--transition-fast),
+      transform var(--transition-fast);
+  }
+
+  .help-tooltip--open {
+    opacity: 1;
+    transform: translateY(0);
+  }
+</style>

--- a/src/lib/components/HelpTooltip.svelte
+++ b/src/lib/components/HelpTooltip.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  /* eslint-disable svelte/no-dom-manipulating */
   import { autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
 
   import Icon from './Icon.svelte';
@@ -24,6 +25,22 @@
   let tooltipY = $state(0);
   const alignEnd = $derived(align === 'end');
   const placement = $derived(alignEnd ? 'top-end' : 'top-start');
+
+  $effect(() => {
+    if (!tooltipElement || tooltipElement.parentElement === document.body) {
+      return;
+    }
+
+    // Keep the floating tooltip out of clipped stacking contexts so it can
+    // overlay the surrounding controls consistently.
+    document.body.appendChild(tooltipElement);
+
+    return () => {
+      if (tooltipElement?.parentElement === document.body) {
+        tooltipElement.remove();
+      }
+    };
+  });
 
   function show(): void {
     if (!disabled) {
@@ -101,23 +118,23 @@
   >
     <Icon name="help" size="var(--icon-size-help)" stroke="var(--icon-stroke-help)" />
   </button>
-  <span
-    {id}
-    bind:this={tooltipElement}
-    class="help-tooltip"
-    class:help-tooltip--open={open}
-    role="tooltip"
-    hidden={!open}
-    style:left={`${tooltipX}px`}
-    style:top={`${tooltipY}px`}
-  >
-    {text}
-  </span>
+</span>
+
+<span
+  {id}
+  bind:this={tooltipElement}
+  class="help-tooltip"
+  class:help-tooltip--open={open}
+  role="tooltip"
+  hidden={!open}
+  style:left={`${tooltipX}px`}
+  style:top={`${tooltipY}px`}
+>
+  {text}
 </span>
 
 <style>
   .help-tooltip-wrapper {
-    --help-tooltip-inline-size: min(36ch, calc(100vw - var(--space-xl)));
     position: relative;
     display: inline-flex;
     align-items: center;
@@ -159,7 +176,7 @@
     inset-block-start: 0;
     inset-inline-start: 0;
     z-index: 30;
-    inline-size: var(--help-tooltip-inline-size);
+    inline-size: min(36ch, calc(100vw - var(--space-xl)));
     padding: var(--space-sm) var(--space-md);
     border-radius: var(--radius-md);
     border: var(--border-width-thin) solid var(--border);

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -9,6 +9,7 @@
     IconChevronDown,
     IconCopy,
     IconFileTypeCss,
+    IconHelpCircle,
     IconPencil,
     IconRefresh,
     IconShare,
@@ -26,6 +27,7 @@
     | 'undo'
     | 'redo'
     | 'edit'
+    | 'help'
     | 'chevron-down'
     | 'status-pass'
     | 'status-fail';
@@ -48,6 +50,7 @@
     undo: IconArrowBackUp,
     redo: IconArrowForwardUp,
     edit: IconPencil,
+    help: IconHelpCircle,
     'chevron-down': IconChevronDown,
     scss: IconBrandSass,
     'status-pass': IconCheck,

--- a/src/lib/components/SliderNumberField.svelte
+++ b/src/lib/components/SliderNumberField.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { tick } from 'svelte';
+  import HelpTooltip from './HelpTooltip.svelte';
 
   interface Props {
     id: string;
@@ -115,14 +116,7 @@
   <div class="label-row">
     <label class="label" id={labelId} for={id}>{label}</label>
     {#if infoButtonLabel && infoTooltipId && infoTooltipText}
-      <span class="help-popover">
-        <button type="button" class="info-button" aria-label={infoButtonLabel}>
-          <span aria-hidden="true">i</span>
-        </button>
-        <span id={infoTooltipId} class="help-tooltip" role="tooltip">
-          {infoTooltipText}
-        </span>
-      </span>
+      <HelpTooltip id={infoTooltipId} label={infoButtonLabel} text={infoTooltipText} align="end" />
     {/if}
   </div>
 
@@ -214,61 +208,6 @@
     text-align: center;
     min-height: var(--touch-target-comfortable);
     padding-block: 0;
-  }
-
-  .help-popover {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-  }
-
-  .info-button {
-    width: var(--touch-target-min);
-    min-width: var(--touch-target-min);
-    height: var(--touch-target-min);
-    border-radius: 50%;
-    border: 1px solid var(--border);
-    background: var(--bg-primary);
-    color: var(--text-secondary);
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-semibold);
-    line-height: 1;
-    cursor: help;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .help-tooltip {
-    position: absolute;
-    inset-block-start: calc(100% + var(--space-xs));
-    inset-inline-end: 0;
-    inset-inline-start: auto;
-    z-index: 20;
-    inline-size: min(32ch, calc(100vw - var(--space-xl)));
-    padding: var(--space-sm) var(--space-md);
-    border-radius: var(--radius-md);
-    border: 1px solid var(--border);
-    background: var(--bg-primary);
-    color: var(--text-primary);
-    font-size: var(--font-size-sm);
-    line-height: var(--line-height-normal);
-    box-shadow: 0 6px 16px color-mix(in oklab, black 14%, transparent);
-    visibility: hidden;
-    opacity: 0;
-    transform: translateY(-2px);
-    pointer-events: none;
-    transition:
-      opacity var(--transition-fast),
-      transform var(--transition-fast),
-      visibility var(--transition-fast);
-  }
-
-  .help-popover:hover .help-tooltip,
-  .help-popover:focus-within .help-tooltip {
-    visibility: visible;
-    opacity: 1;
-    transform: translateY(0);
   }
 
   @media (max-width: 768px) {

--- a/src/lib/help/helpContent.ts
+++ b/src/lib/help/helpContent.ts
@@ -1,0 +1,244 @@
+export interface HelpTopic {
+  label: string;
+  tooltip: string;
+  guide: string;
+}
+
+export interface HelpGuideSection {
+  id: string;
+  title: string;
+  body: string[];
+}
+
+export interface HelpResource {
+  title: string;
+  url: string;
+  description: string;
+}
+
+export const GETTING_STARTED_CALLOUT_STORAGE_KEY = 'chroma11y:getting-started-callout-dismissed';
+
+export const HELP_TOPICS = {
+  baseColor: {
+    label: 'Base color',
+    tooltip: 'Sets the starting hue used to generate palette families.',
+    guide:
+      'Start with a representative brand or product color. Chroma11y converts it into OKLCH so hue, lightness, and chroma can be tuned predictably.'
+  },
+  oklch: {
+    label: 'OKLCH',
+    tooltip: 'A perceptual color model where lightness, chroma, and hue are adjusted separately.',
+    guide:
+      'OKLCH is designed to match human color perception more closely than RGB or HSL. That makes palette ramps easier to tune because lightness changes are more visually consistent.'
+  },
+  lightnessCurve: {
+    label: 'Lightness curve',
+    tooltip: 'Shapes how quickly the palette moves from light swatches to dark swatches.',
+    guide:
+      'The lightness curve controls the spacing between steps. A flatter curve creates gentler changes, while a steeper curve creates more contrast between adjacent swatches.'
+  },
+  bezierCurve: {
+    label: 'Bezier curve',
+    tooltip: 'Adjusts the easing curve used to distribute palette lightness steps.',
+    guide:
+      'The Bezier editor gives precise control over the lightness ramp. Move the handles to emphasize highlights, midtones, or shadows without changing every step by hand.'
+  },
+  warmth: {
+    label: 'Warmth',
+    tooltip: 'Tints neutral swatches warmer or cooler while preserving the palette structure.',
+    guide:
+      'Warmth adds a controlled hue bias to neutral colors. Positive values lean warmer, negative values lean cooler, and custom warmth hue lets you choose the tint direction.'
+  },
+  customWarmthHue: {
+    label: 'Custom warmth hue',
+    tooltip:
+      'Lets you choose the neutral tint hue instead of using the default warm or cool direction.',
+    guide:
+      'Use custom warmth hue when your system needs neutrals that lean toward a specific brand hue or material tone.'
+  },
+  saturation: {
+    label: 'Saturation',
+    tooltip: 'Scales OKLCH chroma to make generated palettes quieter or more vivid.',
+    guide:
+      'Saturation controls chroma. Lower values create more restrained palettes, while higher values keep generated hues closer to the base color intensity.'
+  },
+  numberOfColors: {
+    label: 'Number of colors',
+    tooltip: 'Controls how many steps each palette contains.',
+    guide:
+      'Use more color steps when a design system needs fine-grained surfaces, borders, text, and state colors.'
+  },
+  numberOfPalettes: {
+    label: 'Number of palettes',
+    tooltip: 'Controls how many hue families are generated from the base color.',
+    guide:
+      'Additional palettes rotate around the color wheel from the base color while preserving the same lightness structure.'
+  },
+  contrastAlgorithm: {
+    label: 'Contrast algorithm',
+    tooltip: 'Chooses whether swatch contrast uses WCAG ratios or APCA lightness contrast.',
+    guide:
+      'WCAG ratios are the current compliance baseline. APCA is a newer contrast model that better accounts for perceived lightness and text use cases.'
+  },
+  wcag: {
+    label: 'WCAG',
+    tooltip: 'WCAG 2.2 contrast ratios are the current accessibility compliance reference.',
+    guide:
+      'WCAG contrast compares relative luminance as a ratio. AA and AAA thresholds help identify text and interface colors that meet common accessibility requirements.'
+  },
+  apca: {
+    label: 'APCA',
+    tooltip: 'APCA reports perceptual lightness contrast for practical readability guidance.',
+    guide:
+      'APCA reports contrast as Lc values. It is useful for exploring readable text sizes and weights, but it is not the current WCAG 2.2 conformance method.'
+  },
+  contrastMode: {
+    label: 'Contrast mode',
+    tooltip:
+      'Auto uses palette references; manual lets you choose the low and high contrast colors.',
+    guide:
+      'Use auto mode to evaluate against generated reference swatches. Use manual mode when you need to test against specific product backgrounds or text colors.'
+  },
+  lowReference: {
+    label: 'Low reference',
+    tooltip: 'The lighter reference color used for contrast comparisons in auto mode.',
+    guide:
+      'The low reference usually represents the light end of the palette, such as a page or surface background.'
+  },
+  highReference: {
+    label: 'High reference',
+    tooltip: 'The darker reference color used for contrast comparisons in auto mode.',
+    guide:
+      'The high reference usually represents the dark end of the palette, such as primary text or high-emphasis UI.'
+  },
+  indicatorLevels: {
+    label: 'Indicator levels',
+    tooltip: 'Chooses which contrast thresholds appear on generated swatches.',
+    guide:
+      'Contrast indicators mark swatches that meet selected thresholds, making it faster to scan usable text, UI, and background combinations.'
+  },
+  wcagThreeToOne: {
+    label: 'WCAG 3:1',
+    tooltip:
+      'WCAG 2.2 3:1 threshold for large text, UI components, graphics, and link differentiation.',
+    guide: 'WCAG 3:1 is commonly used for large text and non-text interface elements.'
+  },
+  wcagAA: {
+    label: 'WCAG AA',
+    tooltip: 'WCAG 2.2 AA text threshold: 4.5:1 for normal-size text.',
+    guide: 'WCAG AA is the common minimum target for normal body text.'
+  },
+  wcagAAA: {
+    label: 'WCAG AAA',
+    tooltip: 'WCAG 2.2 AAA text threshold: 7:1 for normal-size text.',
+    guide: 'WCAG AAA is a stricter text contrast target for higher accessibility goals.'
+  },
+  apcaLarge: {
+    label: 'APCA Large',
+    tooltip: 'APCA Lc 45 minimum for larger, heavier text and detailed icons.',
+    guide: 'APCA Large is intended for larger display text and some detailed non-text content.'
+  },
+  apcaFluent: {
+    label: 'APCA Fluent',
+    tooltip: 'APCA Lc 60 minimum for readable content text that is not dense body copy.',
+    guide: 'APCA Fluent is useful for interface copy that users are expected to read comfortably.'
+  },
+  apcaBody: {
+    label: 'APCA Body',
+    tooltip: 'APCA Lc 75 minimum for body text where readability is critical.',
+    guide: 'APCA Body is a stronger readability target for dense or sustained reading.'
+  },
+  colorSpace: {
+    label: 'Color space',
+    tooltip: 'Controls which CSS color format is shown on swatches and used for exports.',
+    guide:
+      'Choose the color space that matches your implementation needs. Hex is broadly compatible, while OKLCH keeps perceptual color data visible.'
+  },
+  gamutMapping: {
+    label: 'Gamut mapping',
+    tooltip: 'Chooses the target display gamut used when rendering generated colors.',
+    guide:
+      'Gamut mapping keeps colors displayable in the selected output space. Wider gamuts can preserve more vivid colors on supported displays.'
+  },
+  gamutWarnings: {
+    label: 'Gamut warnings',
+    tooltip: 'Shows when a swatch has been mapped to fit the selected display gamut.',
+    guide:
+      'Gamut warnings flag colors that need conversion to fit the current output space, which matters when exporting production tokens.'
+  },
+  oklchPrecision: {
+    label: 'OKLCH precision',
+    tooltip: 'Controls how many significant digits OKLCH swatches use for rendering and labels.',
+    guide:
+      'OKLCH precision lets you balance readable labels with exact output. More digits preserve finer color differences.'
+  },
+  exportFormat: {
+    label: 'Export format',
+    tooltip: 'Exports the current palette as shareable URLs, design tokens, CSS, or SCSS.',
+    guide:
+      'Export when the palette is ready to move into a design system or codebase. CSS and SCSS respect the selected display color space.'
+  }
+} as const satisfies Record<string, HelpTopic>;
+
+export type HelpTopicId = keyof typeof HELP_TOPICS;
+
+export const GETTING_STARTED_SECTIONS: HelpGuideSection[] = [
+  {
+    id: 'base-color',
+    title: 'Pick a base color',
+    body: [HELP_TOPICS.baseColor.guide, HELP_TOPICS.numberOfPalettes.guide]
+  },
+  {
+    id: 'oklch',
+    title: 'Work in OKLCH',
+    body: [HELP_TOPICS.oklch.guide, HELP_TOPICS.colorSpace.guide]
+  },
+  {
+    id: 'lightness',
+    title: 'Shape the lightness curve',
+    body: [HELP_TOPICS.lightnessCurve.guide, HELP_TOPICS.bezierCurve.guide]
+  },
+  {
+    id: 'warmth-saturation',
+    title: 'Tune warmth and saturation',
+    body: [HELP_TOPICS.warmth.guide, HELP_TOPICS.saturation.guide]
+  },
+  {
+    id: 'contrast',
+    title: 'Check WCAG and APCA contrast',
+    body: [HELP_TOPICS.contrastAlgorithm.guide, HELP_TOPICS.wcag.guide, HELP_TOPICS.apca.guide]
+  },
+  {
+    id: 'export',
+    title: 'Export and share palettes',
+    body: [HELP_TOPICS.gamutMapping.guide, HELP_TOPICS.exportFormat.guide]
+  }
+];
+
+export const HELP_RESOURCES: HelpResource[] = [
+  {
+    title: 'OKLCH in CSS: why we moved from RGB and HSL',
+    url: 'https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl',
+    description: 'Practical background on why OKLCH is useful for modern color systems.'
+  },
+  {
+    title: 'MDN: oklch()',
+    url: 'https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/oklch',
+    description: 'Reference documentation for the CSS OKLCH color function.'
+  },
+  {
+    title: 'MDN: CSS color values',
+    url: 'https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Colors/Color_values',
+    description: 'Overview of CSS color formats and color spaces.'
+  },
+  {
+    title: 'W3C: Understanding Success Criterion 1.4.3 Contrast Minimum',
+    url: 'https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html',
+    description: 'Official guidance for the WCAG 2.2 contrast minimum requirement.'
+  },
+  {
+    title: 'APCA project and documentation',
+    url: 'https://git.apcacontrast.com/documentation/',
+    description: 'Project documentation for APCA contrast guidance.'
+  }
+];

--- a/src/lib/help/helpDialogStore.ts
+++ b/src/lib/help/helpDialogStore.ts
@@ -1,0 +1,34 @@
+import { writable } from 'svelte/store';
+
+export interface GettingStartedDialogState {
+  open: boolean;
+  opener: HTMLElement | null;
+}
+
+export const gettingStartedDialog = writable<GettingStartedDialogState>({
+  open: false,
+  opener: null
+});
+
+/**
+ * Opens the Getting Started guide and records the element that should receive
+ * focus when the dialog closes.
+ *
+ * @param opener Element that triggered the dialog.
+ */
+export function openGettingStartedGuide(opener: HTMLElement | null = null): void {
+  gettingStartedDialog.set({
+    open: true,
+    opener
+  });
+}
+
+/**
+ * Closes the Getting Started guide.
+ */
+export function closeGettingStartedGuide(): void {
+  gettingStartedDialog.set({
+    open: false,
+    opener: null
+  });
+}

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -139,8 +139,11 @@
 :root {
   --icon-size-disclosure: 16px;
   --icon-size-disclosure-compact: 18px;
+  --icon-size-help: 16px;
+  --icon-size-dialog-close: 18px;
   --icon-stroke-disclosure: 2;
   --icon-stroke-disclosure-compact: 2.35;
+  --icon-stroke-help: 2;
 }
 
 /* ============================================================================

--- a/src/routes/PageContent.svelte
+++ b/src/routes/PageContent.svelte
@@ -83,6 +83,8 @@
   import AppHeader from '$lib/components/AppHeader.svelte';
   import Sidebar from '$lib/components/Sidebar.svelte';
   import ColorInfoDrawer from '$lib/components/ColorInfoDrawer.svelte';
+  import GettingStartedDialog from '$lib/components/GettingStartedDialog.svelte';
+  import GettingStartedCallout from '$lib/components/GettingStartedCallout.svelte';
 
   interface Props {
     scheduler?: PageScheduler;
@@ -1289,6 +1291,7 @@
     onUndoJump={handleHistoryJump}
     onRedoJump={handleHistoryJump}
   />
+  <GettingStartedDialog />
 
   <div class="layout-container">
     <div class="layout" data-testid="app-layout" bind:this={layoutEl}>
@@ -1331,6 +1334,8 @@
               />
             {/key}
           </Card>
+
+          <GettingStartedCallout />
 
           <Card
             title="Constraints"
@@ -1433,6 +1438,8 @@
               />
             {/key}
           </Card>
+
+          <GettingStartedCallout />
 
           <Card
             title="Constraints"


### PR DESCRIPTION
## Summary

Adds a reusable in-app help system with contextual tooltips, a dismissible Getting Started callout, and a modal guide for onboarding concepts like OKLCH, Bezier curves, WCAG/APCA, warmth, and saturation.

## Linked Issue(s)

Closes #40

## Change Type

- [x] `feat`

## Impacted Areas

- [x] UI components / interactions
- [x] Accessibility / keyboard / screen reader behavior
- [x] URL or localStorage persistence
- [x] Tests / CI workflow

## Accessibility Impact

- [x] Improves accessibility

### Accessibility Notes

Tooltips are exposed with `aria-describedby` and `role="tooltip"`; the Getting Started modal traps focus, closes with Escape, and returns focus to its opener.

## Testing

- [x] `npm run lint`
- [x] `npm run check`
- [x] `npm test`
- [x] Targeted tests run (list below)

### Targeted Tests and Results

- `npm run test:unit -- src/lib/components/HelpTooltip.dom.spec.ts src/lib/components/GettingStartedDialog.dom.spec.ts src/lib/components/GettingStartedCallout.dom.spec.ts src/lib/components/ColorControls.dom.spec.ts src/lib/components/ContrastControls.dom.spec.ts src/lib/components/DisplaySettings.dom.spec.ts src/lib/components/ExportButtons.dom.spec.ts`
  - Passed

## UI / Visual Evidence (if applicable)

Not captured in this pass.

## Risk and Rollback

- Risk level: medium
- Rollback plan: revert the three commits on this branch.
