### PR TITLE
feat: add color vision deficiency simulation (#49)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 test-results
 playwright-report
+.playwright-mcp
 lighthouse-report
 .lighthouseci
 coverage

--- a/src/lib/colorUtils.ts
+++ b/src/lib/colorUtils.ts
@@ -10,7 +10,8 @@ import type {
   DisplayColorSpace,
   GamutSpace,
   ContrastAlgorithm,
-  OklchDisplaySignificantDigits
+  OklchDisplaySignificantDigits,
+  CvdMode
 } from '$lib/types';
 
 // Re-export Color so consumers can use it as the OKLCH type
@@ -1100,6 +1101,48 @@ export function colorToCssHsl(color: Color): string {
   }
 }
 
+// Machado et al. 2009, Table 3 — linear sRGB 3×3 matrices at severity 1.0
+// "A Physiologically-based Model for Simulation of Color Vision Deficiency"
+const CVD_MATRICES: Record<Exclude<CvdMode, 'none' | 'achromatopsia'>, number[][]> = {
+  protanopia: [
+    [0.152286, 1.052583, -0.204868],
+    [0.114503, 0.786281, 0.099216],
+    [-0.003882, -0.048116, 1.051998]
+  ],
+  deuteranopia: [
+    [0.367322, 0.860646, -0.227968],
+    [0.280085, 0.672501, 0.047413],
+    [-0.01182, 0.04294, 0.968881]
+  ],
+  tritanopia: [
+    [1.255528, -0.076749, -0.178779],
+    [-0.078411, 0.930809, 0.147602],
+    [0.004733, 0.691367, 0.3039]
+  ]
+};
+
+export function simulateCvd(color: Color, mode: CvdMode): Color {
+  if (mode === 'none') return color;
+  const linear = color.to('srgb-linear');
+  const r = linear.coords[0] ?? 0;
+  const g = linear.coords[1] ?? 0;
+  const b = linear.coords[2] ?? 0;
+  let sr: number, sg: number, sb: number;
+  if (mode === 'achromatopsia') {
+    // BT.709 luminance in linear sRGB
+    const y = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    sr = y;
+    sg = y;
+    sb = y;
+  } else {
+    const m = CVD_MATRICES[mode];
+    sr = m[0][0] * r + m[0][1] * g + m[0][2] * b;
+    sg = m[1][0] * r + m[1][1] * g + m[1][2] * b;
+    sb = m[2][0] * r + m[2][1] * g + m[2][2] * b;
+  }
+  return new Color('srgb-linear', [sr, sg, sb]);
+}
+
 /**
  * Formats a Color object as a CSS string in the given render color space and gamut.
  * This is the main dispatcher used by derived stores and components.
@@ -1112,45 +1155,47 @@ export function colorToCssHsl(color: Color): string {
 export function colorToCssRender(
   color: Color,
   space: DisplayColorSpace,
-  gamut: GamutSpace
+  gamut: GamutSpace,
+  cvdMode: CvdMode = 'none'
 ): string {
+  const c = cvdMode !== 'none' ? simulateCvd(color, cvdMode) : color;
   switch (space) {
     case 'oklch':
-      return colorToCssOklch(color, gamut);
+      return colorToCssOklch(c, gamut);
     case 'hex':
       switch (gamut) {
         case 'p3':
-          return colorToCssP3(color);
+          return colorToCssP3(c);
         case 'rec2020':
-          return colorToCssRec2020(color);
+          return colorToCssRec2020(c);
         default:
-          return colorToCssHex(color);
+          return colorToCssHex(c);
       }
     case 'rgb':
       switch (gamut) {
         case 'p3':
-          return colorToCssP3(color);
+          return colorToCssP3(c);
         case 'rec2020':
-          return colorToCssRec2020(color);
+          return colorToCssRec2020(c);
         default:
-          return colorToCssRgb(color);
+          return colorToCssRgb(c);
       }
     case 'hsl':
       switch (gamut) {
         case 'p3':
-          return colorToCssP3(color);
+          return colorToCssP3(c);
         case 'rec2020':
-          return colorToCssRec2020(color);
+          return colorToCssRec2020(c);
         default:
-          return colorToCssHsl(color);
+          return colorToCssHsl(c);
       }
     default:
-      return colorToCssHex(color);
+      return colorToCssHex(c);
   }
 }
 
 /**
- * Formats a Color for swatch labels/rendering.
+ * Formats a Color for swatch background rendering (simulated when cvdMode is active).
  * Uses compact rounding only for OKLCH to improve readability on swatches while
  * leaving all other formats unchanged.
  */
@@ -1158,12 +1203,14 @@ export function colorToCssSwatchRender(
   color: Color,
   space: DisplayColorSpace,
   gamut: GamutSpace,
-  oklchSignificantDigits: OklchDisplaySignificantDigits = DEFAULT_OKLCH_DISPLAY_SIGNIFICANT_DIGITS
+  oklchSignificantDigits: OklchDisplaySignificantDigits = DEFAULT_OKLCH_DISPLAY_SIGNIFICANT_DIGITS,
+  cvdMode: CvdMode = 'none'
 ): string {
+  const c = cvdMode !== 'none' ? simulateCvd(color, cvdMode) : color;
   if (space === 'oklch') {
-    return colorToCssOklchSwatch(color, gamut, oklchSignificantDigits);
+    return colorToCssOklchSwatch(c, gamut, oklchSignificantDigits);
   }
-  return colorToCssRender(color, space, gamut);
+  return colorToCssRender(c, space, gamut);
 }
 
 // ===== CONTRAST ALGORITHM HELPERS =====

--- a/src/lib/components/ColorSwatch.svelte
+++ b/src/lib/components/ColorSwatch.svelte
@@ -31,6 +31,7 @@
   interface Props {
     color: string;
     displayValue?: string;
+    simulatedColor?: string;
     label?: string;
     oklchColor?: Color | null;
     paletteName?: string;
@@ -43,6 +44,7 @@
   let {
     color,
     displayValue = '',
+    simulatedColor = '',
     label = '',
     oklchColor = null,
     paletteName = '',
@@ -62,6 +64,8 @@
   const activeSwatchPickerLocal = $derived($activeSwatchPicker);
 
   const renderedColor = $derived(displayValue || color);
+  // simulatedColor, if provided, is the CVD-transformed fill; label and interactions use renderedColor
+  const backgroundColor = $derived(simulatedColor || renderedColor);
   const shownValue = $derived(renderedColor);
   const renderedHex = $derived.by(() => {
     try {
@@ -211,17 +215,21 @@
     return groups;
   });
 
-  const textColor = $derived(calculateTextColor(renderedColor, contrastColorsLocal));
+  const textColor = $derived(calculateTextColor(backgroundColor, contrastColorsLocal));
   const indicatorTintAlpha = $derived.by(() => {
     if (!shouldShowIndicators) return INDICATOR_TINT_MAX_ALPHA;
 
     const minimumContrast =
       contrastAlgorithmLocal === 'APCA' ? MIN_APCA_LC_FLUENT : MIN_CONTRAST_RATIO;
-    const baseContrast = getContrastForAlgorithm(renderedColor, textColor, contrastAlgorithmLocal);
+    const baseContrast = getContrastForAlgorithm(
+      backgroundColor,
+      textColor,
+      contrastAlgorithmLocal
+    );
     if (baseContrast < minimumContrast) return 0;
 
     const contrastAtMaxTint = getContrastForAlgorithm(
-      getTintedBackgroundColor(renderedColor, textColor, INDICATOR_TINT_MAX_ALPHA),
+      getTintedBackgroundColor(backgroundColor, textColor, INDICATOR_TINT_MAX_ALPHA),
       textColor,
       contrastAlgorithmLocal
     );
@@ -232,7 +240,7 @@
     for (let i = 0; i < INDICATOR_TINT_SEARCH_ITERATIONS; i++) {
       const mid = (low + high) / 2;
       const contrastAtMidTint = getContrastForAlgorithm(
-        getTintedBackgroundColor(renderedColor, textColor, mid),
+        getTintedBackgroundColor(backgroundColor, textColor, mid),
         textColor,
         contrastAlgorithmLocal
       );
@@ -345,7 +353,7 @@
 <button
   class="color-swatch"
   class:color-swatch--gamut-warning={showGamutWarning}
-  style="background-color: {renderedColor}; color: {textColor}; --swatch-indicator-tint-alpha: {indicatorTintPercent};"
+  style="background-color: {backgroundColor}; color: {textColor}; --swatch-indicator-tint-alpha: {indicatorTintPercent};"
   onclick={() => {
     if (activeSwatchPickerLocal) {
       handlePickerSelection();

--- a/src/lib/components/DisplaySettings.svelte
+++ b/src/lib/components/DisplaySettings.svelte
@@ -3,6 +3,7 @@
   import Icon from './Icon.svelte';
   import CheckboxRow from './CheckboxRow.svelte';
   import HelpTooltip from './HelpTooltip.svelte';
+  import SelectField from './SelectField.svelte';
   import {
     displayColorSpace,
     oklchDisplaySignificantDigits,
@@ -10,6 +11,7 @@
     themePreference,
     swatchLabels,
     showSwatchGamutWarnings,
+    cvdMode,
     updateColorState,
     setThemePreference
   } from '$lib/stores';
@@ -21,7 +23,8 @@
     GamutSpace,
     ThemePreference,
     SwatchLabels,
-    OklchDisplaySignificantDigits
+    OklchDisplaySignificantDigits,
+    CvdMode
   } from '$lib/types';
 
   interface Props {
@@ -47,12 +50,21 @@
   const themePreferenceLocal = $derived($themePreference);
   const swatchLabelsLocal = $derived($swatchLabels);
   const showSwatchGamutWarningsLocal = $derived($showSwatchGamutWarnings);
+  const cvdModeLocal = $derived($cvdMode);
   const swatchStepLabelEnabled = $derived(
     swatchLabelsLocal === 'both' || swatchLabelsLocal === 'step'
   );
   const swatchValueLabelEnabled = $derived(
     swatchLabelsLocal === 'both' || swatchLabelsLocal === 'value'
   );
+
+  const CVD_OPTIONS: { value: CvdMode; label: string }[] = [
+    { value: 'none', label: 'None' },
+    { value: 'protanopia', label: 'Protanopia (red-blind)' },
+    { value: 'deuteranopia', label: 'Deuteranopia (green-blind)' },
+    { value: 'tritanopia', label: 'Tritanopia (blue-blind)' },
+    { value: 'achromatopsia', label: 'Achromatopsia (full)' }
+  ];
 
   function setOklchSignificantDigits(value: number, shouldAnnounce: boolean): void {
     const clampedValue = clampOklchDisplaySignificantDigits(value) as OklchDisplaySignificantDigits;
@@ -63,25 +75,25 @@
     }
   }
 
-  function handleDisplayColorSpaceChange(event: Event) {
-    const value = (event.target as HTMLSelectElement).value as DisplayColorSpace;
-    if (value === 'hex') {
-      updateColorState({ displayColorSpace: value, gamutSpace: 'srgb' });
+  function handleDisplayColorSpaceChange(value: string) {
+    const space = value as DisplayColorSpace;
+    if (space === 'hex') {
+      updateColorState({ displayColorSpace: space, gamutSpace: 'srgb' });
       announce('Display color space changed to hex. Gamut mapping fixed to sRGB');
       onHistoryCommit?.('Display color space changed');
       return;
     }
 
-    updateColorState({ displayColorSpace: value });
-    announce(`Display color space changed to ${value}`);
+    updateColorState({ displayColorSpace: space });
+    announce(`Display color space changed to ${space}`);
     onHistoryCommit?.('Display color space changed');
   }
 
-  function handleGamutSpaceChange(event: Event) {
-    const value = (event.target as HTMLSelectElement).value as GamutSpace;
-    updateColorState({ gamutSpace: value });
+  function handleGamutSpaceChange(value: string) {
+    const space = value as GamutSpace;
+    updateColorState({ gamutSpace: space });
     announce(
-      `Gamut mapping changed to ${value === 'srgb' ? 'sRGB' : value === 'p3' ? 'Display P3' : 'Rec. 2020'}`
+      `Gamut mapping changed to ${space === 'srgb' ? 'sRGB' : space === 'p3' ? 'Display P3' : 'Rec. 2020'}`
     );
     onHistoryCommit?.('Gamut mapping changed');
   }
@@ -96,11 +108,22 @@
     setOklchSignificantDigits(parsed, true);
   }
 
-  function handleThemePreferenceChange(event: Event) {
-    const value = (event.target as HTMLSelectElement).value as ThemePreference;
-    setThemePreference(value);
-    announce(`Theme preference changed to ${value === 'auto' ? 'auto (system)' : value}`);
+  function handleThemePreferenceChange(value: string) {
+    const pref = value as ThemePreference;
+    setThemePreference(pref);
+    announce(`Theme preference changed to ${pref === 'auto' ? 'auto (system)' : pref}`);
     onHistoryCommit?.('Theme preference changed');
+  }
+
+  function handleCvdModeChange(value: string) {
+    const mode = value as CvdMode;
+    updateColorState({ cvdMode: mode });
+    announce(
+      mode === 'none'
+        ? 'Color vision simulation off'
+        : `Simulating ${CVD_OPTIONS.find((o) => o.value === mode)?.label ?? mode}`
+    );
+    onHistoryCommit?.('CVD simulation changed');
   }
 
   function toSwatchLabels(stepEnabled: boolean, valueEnabled: boolean): SwatchLabels {
@@ -142,43 +165,47 @@
 
 <section class="display-settings" data-testid="display-settings">
   <section class="control-subsection">
-    <div class="field">
-      <div class="label-row">
-        <label class="label" for="display-color-space">Color Space</label>
-        <HelpTooltip
-          id="color-space-help"
-          label="Explain Color Space"
-          text={HELP_TOPICS.colorSpace.tooltip}
-        />
-      </div>
-      <select
-        class="select"
-        id="display-color-space"
-        value={displayColorSpaceLocal}
-        onchange={handleDisplayColorSpaceChange}
-        aria-label="Display color space format"
-      >
-        <option value="hex">Hex</option>
-        <option value="rgb">RGB</option>
-        <option value="oklch">OKLCH</option>
-        <option value="hsl">HSL</option>
-      </select>
-    </div>
+    <SelectField
+      id="display-color-space"
+      label="Color Space"
+      value={displayColorSpaceLocal}
+      options={[
+        { value: 'hex', label: 'Hex' },
+        { value: 'rgb', label: 'RGB' },
+        { value: 'oklch', label: 'OKLCH' },
+        { value: 'hsl', label: 'HSL' }
+      ]}
+      ariaLabel="Display color space format"
+      helpId="color-space-help"
+      helpLabel="Explain Color Space"
+      helpText={HELP_TOPICS.colorSpace.tooltip}
+      onchange={handleDisplayColorSpaceChange}
+    />
 
-    <div class="field">
-      <label class="label" for="theme-preference">Theme</label>
-      <select
-        class="select"
-        id="theme-preference"
-        value={themePreferenceLocal}
-        onchange={handleThemePreferenceChange}
-        aria-label="Theme preference"
-      >
-        <option value="light">Light</option>
-        <option value="dark">Dark</option>
-        <option value="auto">Auto (System)</option>
-      </select>
-    </div>
+    <SelectField
+      id="theme-preference"
+      label="Theme"
+      value={themePreferenceLocal}
+      options={[
+        { value: 'light', label: 'Light' },
+        { value: 'dark', label: 'Dark' },
+        { value: 'auto', label: 'Auto (System)' }
+      ]}
+      ariaLabel="Theme preference"
+      onchange={handleThemePreferenceChange}
+    />
+
+    <SelectField
+      id="cvd-mode"
+      label="Color Vision Simulation"
+      value={cvdModeLocal}
+      options={CVD_OPTIONS}
+      ariaLabel="Color vision deficiency simulation"
+      helpId="cvd-mode-help"
+      helpLabel="Explain Color Vision Simulation"
+      helpText={HELP_TOPICS.cvdSimulation.tooltip}
+      onchange={handleCvdModeChange}
+    />
 
     <div class="field">
       <span class="label">Swatch Labels</span>
@@ -245,34 +272,26 @@
           />
         {/if}
 
-        <div class="field">
-          <div class="label-row">
-            <label class="label" for="gamut-space">Gamut Mapping</label>
-            <HelpTooltip
-              id="gamut-mapping-help"
-              label="Explain Gamut Mapping"
-              text={HELP_TOPICS.gamutMapping.tooltip}
-            />
-          </div>
-          <select
-            class="select"
-            id="gamut-space"
-            value={gamutSpaceLocal}
-            onchange={handleGamutSpaceChange}
-            aria-label="Gamut mapping target"
-            disabled={displayColorSpaceLocal === 'hex'}
-            aria-describedby={displayColorSpaceLocal === 'hex' ? 'gamut-space-help' : undefined}
-          >
-            <option value="srgb">sRGB</option>
-            <option value="p3">Display P3</option>
-            <option value="rec2020">Rec. 2020</option>
-          </select>
-          {#if displayColorSpaceLocal === 'hex'}
-            <p id="gamut-space-help" class="field-help">
-              Hex output is fixed to sRGB, so gamut mapping cannot be changed.
-            </p>
-          {/if}
-        </div>
+        <SelectField
+          id="gamut-space"
+          label="Gamut Mapping"
+          value={gamutSpaceLocal}
+          options={[
+            { value: 'srgb', label: 'sRGB' },
+            { value: 'p3', label: 'Display P3' },
+            { value: 'rec2020', label: 'Rec. 2020' }
+          ]}
+          ariaLabel="Gamut mapping target"
+          helpId="gamut-mapping-help"
+          helpLabel="Explain Gamut Mapping"
+          helpText={HELP_TOPICS.gamutMapping.tooltip}
+          disabled={displayColorSpaceLocal === 'hex'}
+          describedById={displayColorSpaceLocal === 'hex' ? 'gamut-space-help' : undefined}
+          fieldHelp={displayColorSpaceLocal === 'hex'
+            ? 'Hex output is fixed to sRGB, so gamut mapping cannot be changed.'
+            : undefined}
+          onchange={handleGamutSpaceChange}
+        />
 
         <div class="field">
           <div class="label-row">
@@ -419,12 +438,6 @@
     gap: var(--space-md);
     padding: var(--space-md);
     border-top: var(--border-width-thin) solid color-mix(in oklab, var(--border) 42%, transparent);
-  }
-
-  .field-help {
-    margin: var(--space-xs) 0 0;
-    font-size: var(--font-size-xs);
-    color: var(--text-secondary);
   }
 
   @media (max-width: 980px) {

--- a/src/lib/components/NeutralPalette.svelte
+++ b/src/lib/components/NeutralPalette.svelte
@@ -20,6 +20,7 @@
     neutrals?: Color[];
     neutralsHex?: string[];
     neutralsDisplay?: string[];
+    neutralsSimulatedDisplay?: string[] | null;
     lightnessNudgerValues?: number[];
     onHistoryCommit?: (label: string) => void;
   }
@@ -28,6 +29,7 @@
     neutrals = [],
     neutralsHex = [],
     neutralsDisplay = [],
+    neutralsSimulatedDisplay = null,
     lightnessNudgerValues = [],
     onHistoryCommit
   }: Props = $props();
@@ -132,6 +134,7 @@
           <ColorSwatch
             {color}
             displayValue={neutralsDisplay[index] ?? color}
+            simulatedColor={neutralsSimulatedDisplay?.[index] ?? ''}
             label={String(index * 10)}
             oklchColor={neutrals[index] ?? null}
             paletteName={neutralName}

--- a/src/lib/components/NoticeBanner.svelte
+++ b/src/lib/components/NoticeBanner.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import Icon from './Icon.svelte';
+
+  interface Props {
+    tone?: 'info' | 'warning';
+    title: string;
+    body: string;
+  }
+
+  let { tone = 'info', title, body }: Props = $props();
+</script>
+
+<div class="notice-banner notice-banner--{tone}" role="status" aria-live="polite">
+  <span class="notice-icon" aria-hidden="true">
+    <Icon name={tone === 'warning' ? 'status-fail' : 'help'} size="16px" />
+  </span>
+  <div class="notice-copy">
+    <span class="notice-title">{title}</span>
+    <span class="notice-body">{body}</span>
+  </div>
+</div>
+
+<style>
+  .notice-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-sm);
+    padding: var(--space-sm) var(--space-md);
+    border-radius: var(--radius-md);
+    border: var(--border-width-thin) solid transparent;
+    font-size: var(--font-size-sm);
+  }
+
+  .notice-banner--info {
+    background: color-mix(in oklab, var(--accent) 8%, var(--bg-primary));
+    border-color: color-mix(in oklab, var(--accent) 35%, var(--border));
+    color: var(--text-primary);
+  }
+
+  .notice-banner--info .notice-icon {
+    color: color-mix(in oklab, var(--accent) 72%, var(--text-primary));
+  }
+
+  .notice-banner--warning {
+    background: var(--badge-warning-bg);
+    border-color: var(--badge-warning-border);
+    color: var(--badge-warning-text);
+  }
+
+  .notice-icon {
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  .notice-copy {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  .notice-title {
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .notice-body {
+    color: var(--text-secondary);
+    line-height: var(--line-height-normal);
+  }
+
+  .notice-banner--warning .notice-body {
+    color: inherit;
+  }
+</style>

--- a/src/lib/components/PaletteGrid.svelte
+++ b/src/lib/components/PaletteGrid.svelte
@@ -20,6 +20,7 @@
     palettes?: Color[][];
     palettesHex?: string[][];
     palettesDisplay?: string[][];
+    palettesSimulatedDisplay?: string[][] | null;
     hueNudgerValues?: number[];
     onHistoryCommit?: (label: string) => void;
   }
@@ -28,6 +29,7 @@
     palettes = [],
     palettesHex = [],
     palettesDisplay = [],
+    palettesSimulatedDisplay = null,
     hueNudgerValues = [],
     onHistoryCommit
   }: Props = $props();
@@ -192,6 +194,7 @@
               <ColorSwatch
                 {color}
                 displayValue={palettesDisplay[paletteIndex]?.[index] ?? color}
+                simulatedColor={palettesSimulatedDisplay?.[paletteIndex]?.[index] ?? ''}
                 label={String(index * 10)}
                 oklchColor={palettes[paletteIndex]?.[index] ?? null}
                 paletteName={paletteNames[paletteIndex]}

--- a/src/lib/components/SelectField.svelte
+++ b/src/lib/components/SelectField.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import HelpTooltip from './HelpTooltip.svelte';
+
+  interface SelectOption {
+    value: string;
+    label: string;
+  }
+
+  interface Props {
+    id: string;
+    label: string;
+    value: string;
+    options: SelectOption[];
+    ariaLabel?: string;
+    helpId?: string;
+    helpLabel?: string;
+    helpText?: string;
+    disabled?: boolean;
+    describedById?: string;
+    fieldHelp?: string;
+    onchange: (value: string) => void;
+  }
+
+  let {
+    id,
+    label,
+    value,
+    options,
+    ariaLabel,
+    helpId,
+    helpLabel,
+    helpText,
+    disabled = false,
+    describedById,
+    fieldHelp,
+    onchange
+  }: Props = $props();
+
+  function handleChange(event: Event) {
+    onchange((event.target as HTMLSelectElement).value);
+  }
+</script>
+
+<div class="field">
+  <div class="label-row">
+    <label class="label" for={id}>{label}</label>
+    {#if helpId && helpLabel && helpText}
+      <HelpTooltip id={helpId} label={helpLabel} text={helpText} />
+    {/if}
+  </div>
+  <select
+    class="select"
+    {id}
+    {value}
+    {disabled}
+    aria-label={ariaLabel}
+    aria-describedby={describedById}
+    onchange={handleChange}
+  >
+    {#each options as option (option.value)}
+      <option value={option.value}>{option.label}</option>
+    {/each}
+  </select>
+  {#if fieldHelp}
+    <p id={describedById} class="field-help">{fieldHelp}</p>
+  {/if}
+</div>
+
+<style>
+  .field {
+    display: grid;
+    gap: var(--space-xs);
+  }
+
+  .label-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    flex-wrap: wrap;
+  }
+</style>

--- a/src/lib/help/helpContent.ts
+++ b/src/lib/help/helpContent.ts
@@ -177,6 +177,13 @@ export const HELP_TOPICS = {
     tooltip: 'Exports the current palette as shareable URLs, design tokens, CSS, or SCSS.',
     guide:
       'Export when the palette is ready to move into a design system or codebase. CSS and SCSS respect the selected display color space.'
+  },
+  cvdSimulation: {
+    label: 'Color vision simulation',
+    tooltip:
+      'Simulates how swatches appear to users with color vision deficiencies. Swatch labels and contrast checks always show real values.',
+    guide:
+      'Color vision deficiency simulation approximates how a palette looks to users with protanopia (red-blind), deuteranopia (green-blind), tritanopia (blue-blind), or achromatopsia (full color blindness). Only the swatch fill is simulated — hex values, contrast badges, and exports are unchanged.'
   }
 } as const satisfies Record<string, HelpTopic>;
 

--- a/src/lib/storageUtils.ts
+++ b/src/lib/storageUtils.ts
@@ -12,7 +12,8 @@ import type {
   ContrastAlgorithm,
   OklchDisplaySignificantDigits,
   SwatchContrastIndicators,
-  ContrastReference
+  ContrastReference,
+  CvdMode
 } from './types';
 import { isValidConstraint } from './constraintValidation';
 import { normalizeCustomPaletteName, normalizeCustomPaletteNames } from './paletteNameUtils';
@@ -39,6 +40,13 @@ const VALID_THEME_PREFS: ThemePreference[] = ['light', 'dark', 'auto'];
 const VALID_SWATCH_LABELS: SwatchLabels[] = ['both', 'step', 'value', 'none'];
 const VALID_CONTRAST_ALGOS: ContrastAlgorithm[] = ['WCAG', 'APCA'];
 const VALID_OKLCH_SIG_DIGITS: OklchDisplaySignificantDigits[] = [1, 2, 3, 4, 5, 6];
+const VALID_CVD_MODES: CvdMode[] = [
+  'none',
+  'protanopia',
+  'deuteranopia',
+  'tritanopia',
+  'achromatopsia'
+];
 function isValidSwatchContrastIndicators(value: unknown): value is SwatchContrastIndicators {
   if (typeof value !== 'object' || value === null) return false;
 
@@ -199,6 +207,9 @@ export function loadStateFromStorage(): StoredColorState | null {
       )
     ) {
       delete state.oklchDisplaySignificantDigits;
+    }
+    if (state.cvdMode && !VALID_CVD_MODES.includes(state.cvdMode as CvdMode)) {
+      delete state.cvdMode;
     }
     if (state.lowReference && !isValidContrastReference(state.lowReference)) {
       delete state.lowReference;

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -14,7 +14,8 @@ import type {
   Constraint,
   SolverAdjustmentSnapshot,
   ConstraintSolverSummary,
-  ConstraintSolveRunState
+  ConstraintSolveRunState,
+  CvdMode
 } from '$lib/types';
 
 /**
@@ -58,6 +59,7 @@ interface ColorState {
   contrastAlgorithm: ContrastAlgorithm;
   solveAdjacentStopLows: boolean;
   oklchDisplaySignificantDigits: OklchDisplaySignificantDigits;
+  cvdMode: CvdMode;
   customNeutralName?: string;
   customPaletteNames?: string[];
   constraints: Constraint[];
@@ -154,6 +156,7 @@ const DEFAULT_STATE = {
   contrastAlgorithm: 'WCAG' as ContrastAlgorithm,
   solveAdjacentStopLows: true,
   oklchDisplaySignificantDigits: 4 as OklchDisplaySignificantDigits,
+  cvdMode: 'none' as CvdMode,
   constraints: [] as Constraint[],
   solverAdjustmentSnapshot: null as SolverAdjustmentSnapshot | null,
   constraintSolverSummary: null as ConstraintSolverSummary | null
@@ -273,6 +276,9 @@ export const paletteChromaNudgers = derived(
   ($colorStore) => $colorStore.paletteChromaNudgers
 );
 
+// Derived store for CVD simulation mode
+export const cvdMode = derived(colorStore, ($colorStore) => $colorStore.cvdMode);
+
 // Derived store for display color space
 export const displayColorSpace = derived(
   colorStore,
@@ -385,6 +391,36 @@ export const palettesSwatchDisplay = derived(colorStore, ($colorStore) =>
       )
     )
   )
+);
+
+// Derived store for neutrals simulated background colors (CVD mode applied, no label rounding)
+export const neutralsSimulatedDisplay = derived(colorStore, ($colorStore) =>
+  $colorStore.cvdMode === 'none'
+    ? null
+    : $colorStore.neutrals.map((c) =>
+        colorToCssRender(
+          c,
+          $colorStore.displayColorSpace,
+          $colorStore.gamutSpace,
+          $colorStore.cvdMode
+        )
+      )
+);
+
+// Derived store for palettes simulated background colors (CVD mode applied, no label rounding)
+export const palettesSimulatedDisplay = derived(colorStore, ($colorStore) =>
+  $colorStore.cvdMode === 'none'
+    ? null
+    : $colorStore.palettes.map((palette) =>
+        palette.map((c) =>
+          colorToCssRender(
+            c,
+            $colorStore.displayColorSpace,
+            $colorStore.gamutSpace,
+            $colorStore.cvdMode
+          )
+        )
+      )
 );
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,6 +13,9 @@ export type SwatchLabels = 'both' | 'step' | 'value' | 'none';
 /** Supported contrast algorithm identifiers */
 export type ContrastAlgorithm = 'WCAG' | 'APCA';
 
+/** Color vision deficiency simulation modes */
+export type CvdMode = 'none' | 'protanopia' | 'deuteranopia' | 'tritanopia' | 'achromatopsia';
+
 /** Contrast reference source kinds for auto contrast mode */
 export type ContrastReferenceKind = 'neutral' | 'palette';
 
@@ -238,6 +241,7 @@ export interface SerializableColorState {
   contrastAlgorithm?: ContrastAlgorithm;
   solveAdjacentStopLows?: boolean;
   oklchDisplaySignificantDigits?: OklchDisplaySignificantDigits;
+  cvdMode?: CvdMode;
   customNeutralName?: string;
   customPaletteNames?: string[];
   constraints?: Constraint[];

--- a/src/lib/urlUtils.ts
+++ b/src/lib/urlUtils.ts
@@ -11,7 +11,8 @@ import type {
   ContrastAlgorithm,
   OklchDisplaySignificantDigits,
   SwatchContrastIndicators,
-  ContrastReference
+  ContrastReference,
+  CvdMode
 } from './types';
 import type { Constraint } from './types';
 import { isValidConstraint } from './constraintValidation';
@@ -25,6 +26,13 @@ const VALID_GAMUT_SPACES: GamutSpace[] = ['srgb', 'p3', 'rec2020'];
 const VALID_SWATCH_LABELS: SwatchLabels[] = ['both', 'step', 'value', 'none'];
 const VALID_CONTRAST_ALGOS: ContrastAlgorithm[] = ['WCAG', 'APCA'];
 const VALID_OKLCH_SIG_DIGITS: OklchDisplaySignificantDigits[] = [1, 2, 3, 4, 5, 6];
+const VALID_CVD_MODES: CvdMode[] = [
+  'none',
+  'protanopia',
+  'deuteranopia',
+  'tritanopia',
+  'achromatopsia'
+];
 const DEFAULT_SWATCH_CONTRAST_INDICATORS: SwatchContrastIndicators = {
   wcagThreeToOne: true,
   wcagAA: true,
@@ -302,6 +310,7 @@ export function encodeStateToUrl(state: UrlColorState): string {
   if (state.constraintSolverSummary) {
     params.set('cs', encodeJsonState(state.constraintSolverSummary));
   }
+  if (state.cvdMode && state.cvdMode !== 'none') params.set('cvd', state.cvdMode);
 
   return params.toString();
 }
@@ -513,6 +522,9 @@ export function decodeStateFromUrl(searchParams: URLSearchParams): UrlColorState
   if (constraintSolverSummary) {
     state.constraintSolverSummary = decodeJsonState(constraintSolverSummary) ?? undefined;
   }
+
+  const cvd = searchParams.get('cvd');
+  if (cvd && VALID_CVD_MODES.includes(cvd as CvdMode)) state.cvdMode = cvd as CvdMode;
 
   const effectiveDisplaySpace = state.displayColorSpace ?? 'hex';
   if (state.gamutSpace && state.gamutSpace !== 'srgb' && effectiveDisplaySpace === 'hex') {

--- a/src/routes/PageContent.svelte
+++ b/src/routes/PageContent.svelte
@@ -46,6 +46,9 @@
     constraints,
     solverAdjustmentSnapshot,
     constraintSolverSummary,
+    cvdMode,
+    neutralsSimulatedDisplay,
+    palettesSimulatedDisplay,
     updateColorState,
     updateContrastFromNeutrals,
     resetColorState,
@@ -86,6 +89,8 @@
   import ExportPreviewDialog from '$lib/components/ExportPreviewDialog.svelte';
   import GettingStartedDialog from '$lib/components/GettingStartedDialog.svelte';
   import GettingStartedCallout from '$lib/components/GettingStartedCallout.svelte';
+  import NoticeBanner from '$lib/components/NoticeBanner.svelte';
+  import type { CvdMode } from '$lib/types';
 
   interface Props {
     scheduler?: PageScheduler;
@@ -144,6 +149,16 @@
   let constraintsLocal = $derived($constraints);
   let solverAdjustmentSnapshotLocal = $derived($solverAdjustmentSnapshot);
   let constraintSolverSummaryLocal = $derived($constraintSolverSummary);
+  let cvdModeLocal = $derived($cvdMode);
+  let neutralsSimulatedDisplayLocal = $derived($neutralsSimulatedDisplay);
+  let palettesSimulatedDisplayLocal = $derived($palettesSimulatedDisplay);
+
+  const CVD_BANNER_TEXT: Record<Exclude<CvdMode, 'none'>, string> = {
+    protanopia: 'Simulating Protanopia (red-blind)',
+    deuteranopia: 'Simulating Deuteranopia (green-blind)',
+    tritanopia: 'Simulating Tritanopia (blue-blind)',
+    achromatopsia: 'Simulating Achromatopsia (full color blindness)'
+  };
   let constraintNeutralLabel = $derived(
     neutralsHexLocal.length > 0
       ? resolveNeutralPaletteName(neutralsHexLocal, contrastColorsLocal.low, customNeutralNameLocal)
@@ -1114,6 +1129,7 @@
       solveAdjacentStopLows: solveAdjacentStopLowsLocal,
       oklchDisplaySignificantDigits: oklchDisplaySignificantDigitsLocal,
       themePreference: themePreferenceLocal,
+      cvdMode: cvdModeLocal,
       customNeutralName: customNeutralNameLocal,
       customPaletteNames: customPaletteNamesLocal,
       constraints: constraintsLocal,
@@ -1222,6 +1238,9 @@
     }
     if (urlState.constraintSolverSummary !== undefined) {
       stateUpdate.constraintSolverSummary = urlState.constraintSolverSummary;
+    }
+    if (urlState.cvdMode !== undefined) {
+      stateUpdate.cvdMode = urlState.cvdMode;
     }
 
     // Apply stored values after theme preference to ensure they override any defaults
@@ -1493,11 +1512,19 @@
         data-testid="app-content"
       >
         <div class="content-inner">
+          {#if cvdModeLocal !== 'none'}
+            <NoticeBanner
+              tone="info"
+              title={CVD_BANNER_TEXT[cvdModeLocal]}
+              body="Swatch fills approximate how this palette appears to viewers with this condition. Hex values, contrast badges, and exports remain unchanged."
+            />
+          {/if}
           {#key `neutral-palette-${historyRestoreRevision}`}
             <NeutralPalette
               neutrals={neutralsLocal}
               neutralsHex={neutralsHexLocal}
               neutralsDisplay={neutralsSwatchDisplayLocal}
+              neutralsSimulatedDisplay={neutralsSimulatedDisplayLocal}
               {lightnessNudgerValues}
               onHistoryCommit={scheduleHistoryCommit}
             />
@@ -1507,6 +1534,7 @@
               palettes={palettesLocal}
               palettesHex={palettesHexLocal}
               palettesDisplay={palettesSwatchDisplayLocal}
+              palettesSimulatedDisplay={palettesSimulatedDisplayLocal}
               {hueNudgerValues}
               onHistoryCommit={scheduleHistoryCommit}
             />


### PR DESCRIPTION
## Summary

Adds color vision deficiency (CVD) simulation mode to help accessibility professionals verify palette accessibility for users with color vision deficiencies. The feature implements four types of CVD simulation using scientifically-based transformation matrices.

- Simulates Protanopia (red-blind), Deuteranopia (green-blind), Tritanopia (blue-blind), and Achromatopsia (complete color blindness)
- Shows simulated swatch colors while keeping all data (hex values, contrast badges, exports) unchanged
- Persists setting in localStorage and URL for sharing palettes with simulation mode active
- Includes help content and accessibility announcements

Closes #49

## Change Type

- [x] `feat`
- [ ] `fix`
- [ ] `tweak`
- [ ] `refactor`
- [ ] `test`
- [ ] `docs`
- [ ] `chore`

## Impacted Areas

- [x] Color generation / contrast logic
- [x] UI components / interactions
- [x] Accessibility / keyboard / screen reader behavior
- [x] URL or localStorage persistence
- [ ] Export formats
- [ ] Tests / CI workflow
- [ ] Documentation only
- [ ] Dependencies only

## Accessibility Impact

- [ ] No accessibility impact
- [x] Improves accessibility
- [ ] Potential accessibility risk (details below)

### Accessibility Notes

- Adds screen reader announcements when CVD mode changes
- CVD simulation only affects visual display, not data values or contrast calculations
- All original hex values remain selectable and accessible
- Follows WCAG principles for simulating color vision deficiency as an accessibility aid

## Testing

- [x] \`npm run lint\`
- [x] \`npm run check\`
- [x] \`npm test\`
- [ ] Targeted tests run (list below)

### Targeted Tests and Results

All 38 test files with 619 total tests passed.

## UI / Visual Evidence (if applicable)

Visual changes when CVD simulation is active:
- New dropdown selector in Display Settings
- Information banner indicating active CVD mode
- Swatch fills display color-simulated appearance
- Original hex values and contrast remain unchanged

## Risk and Rollback

- Risk level: low
- Rollback plan: Simple revert of all commits on this branch; feature is opt-in with default 'none' mode