### PR TITLE
feat: complete reference comparison workflows (#197)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,62 @@ _Avoid_: comparison mode, side-by-side mode
 An explicit presentation state layered on top of **Reference View** that emphasizes differences between the current and reference sides.
 _Avoid_: default comparison, automatic compare mode
 
+**Configuration Diff**:
+An explanation of how the **Current Palette Configuration** differs from the **Reference Configuration** that appears in **Comparison View**.
+_Avoid_: settings diff, config delta
+
+**Configuration Diff Entry**:
+A single explained difference inside a **Configuration Diff** rather than a coarse summary of a whole category.
+_Avoid_: catch-all change line, lumped diff
+
+**Comparison Metric**:
+The color-difference method **Comparison View** uses to evaluate swatch color changes.
+_Avoid_: diff algorithm, compare math
+
+**Swatch Change Threshold**:
+The minimum color difference, measured in the selected **Comparison Metric**, before a swatch gets a color-only **Change Annotation** in **Comparison View**.
+_Avoid_: sensitivity percent, compare slider
+
+**Constraint**:
+An authored rule in the **Palette Configuration** that expresses a target color or contrast requirement for the palette system.
+_Avoid_: solve output, optimization result
+
+**Custom Naming**:
+User-authored palette-name overrides in the **Palette Configuration** for the neutral palette or generated palettes.
+_Avoid_: auto names, derived labels
+
+**Contrast Reference**:
+The selected swatch in auto contrast mode that determines a low or high contrast color in the **Palette Configuration**.
+_Avoid_: resolved contrast color, manual contrast input
+
+**Contrast Algorithm**:
+The shared inspection method used to evaluate contrast while reading current and reference output.
+_Avoid_: frozen reference rule, authored contrast setting
+
+**Theme Preference**:
+The authored theme selection in the **Palette Configuration** that chooses the light, dark, or auto theme behavior used to generate the palette system.
+_Avoid_: viewer theme, cosmetic mode
+
+**Resolved Theme**:
+The concrete light or dark theme actually used to generate palette output at a given moment.
+_Avoid_: inspection theme, cosmetic theme result
+
+**Resolved Theme Drift**:
+Palette-output differences caused by a current `auto` theme resolving differently from the frozen reference baseline even though the authored **Theme Preference** still matches.
+_Avoid_: theme config change, viewer bug
+
+**Shared Inspection Settings**:
+Read-time viewing settings such as display color space, gamut mapping, swatch labels, gamut-warning visibility, contrast-indicator visibility and levels, contrast algorithm, and CVD simulation that affect how both sides are inspected without becoming authored differences between the current and reference configurations.
+_Avoid_: pinned config differences, comparison settings
+
+**Comparison Settings**:
+Local user preferences that tune how **Comparison View** explains differences without becoming part of shared URL state or the pinned **Reference Configuration**.
+_Avoid_: reference state, share settings
+
+**Reset to Defaults**:
+An explicit action that restores the current workspace to the default palette configuration and default **Comparison Settings**.
+_Avoid_: clear reference, preserve compare prefs
+
 **Change Annotation**:
 A visible indicator in **Comparison View** that calls out a difference between current and reference output.
 _Avoid_: diff badge, compare marker
@@ -46,7 +102,53 @@ _Avoid_: cosmetic change, visual-only diff
 - A **Reference Configuration** causes **Reference View** to become the default presentation state
 - **Comparison View** requires an existing **Reference Configuration**
 - **Comparison View** preserves the side-by-side structure of **Reference View** while adding explicit change emphasis
+- A **Configuration Diff** belongs to **Comparison View**, not **Reference View**
+- A **Configuration Diff** is composed of individual **Configuration Diff Entry** items
+- A **Configuration Diff** appears in the main **Comparison View** reading area, not in the sidebar controls
+- A **Configuration Diff** stays visible with an explicit success state when there are no configuration-level differences
+- A **Configuration Diff Entry** reads from **Reference Configuration** to **Current Palette Configuration**
+- A **Reference Configuration** includes authored **Constraint** definitions
+- A **Reference Configuration** excludes **Shared Inspection Settings**
+- Editing an existing **Constraint** produces a changed **Configuration Diff Entry**, not a remove-and-add pair
+- Enabling or disabling a **Constraint** changes the **Palette Configuration** and belongs in **Configuration Diff**
+- **Shared Inspection Settings** are excluded from **Configuration Diff**
+- **Shared Inspection Settings** are applied symmetrically to both current and reference sides while reading **Comparison View**
+- **Contrast Algorithm** is a **Shared Inspection Setting**
+- **Theme Preference** belongs to the authored **Palette Configuration**, not **Shared Inspection Settings**
+- A **Reference Configuration** pinned under **Theme Preference** `auto` preserves that authored choice while also freezing the **Resolved Theme** that generated the baseline
+- Restoring a **Reference Configuration** reproduces its frozen **Resolved Theme** so the current palette can exactly match the pinned baseline
+- An authored **Theme Preference** change creates a **Configuration Diff** entry even if the generated output happens to match
+- Matching authored **Theme Preference** values do not create a **Configuration Diff** entry just because their **Resolved Theme** differs
+- **Resolved Theme Drift** can appear in **Comparison View** without creating a **Configuration Diff** entry
+- A **Resolved Theme Drift** note remains visible even when other **Configuration Diff** entries also exist
+- **Resolved Theme Drift** remains a theme-specific concept unless another real class of non-authored output drift appears
+- A **Resolved Theme Drift** note belongs to **Comparison View**, not **Reference View**
+- A **Resolved Theme Drift** note appears above **Configuration Diff** in **Comparison View**
+- A **Resolved Theme Drift** note explicitly names the current and pinned **Resolved Theme** values
+- A **Resolved Theme Drift** note appears only when both sides still use authored `auto` **Theme Preference** values but their **Resolved Theme** values differ
+- When **Resolved Theme Drift** is the only explanation, **Configuration Diff** still shows its explicit success state beneath the drift note
+- **Theme Preference** appears in the generation portion of **Configuration Diff**
+- A **Theme Preference** diff entry stays anchored on authored values and includes **Resolved Theme** only as supporting detail when `auto` is involved
+- A one-sided **Configuration Diff Entry** uses explicit add/remove language instead of an empty-value comparison
+- Structural generation changes do not create separate **Configuration Diff Entry** items for untouched default-valued slots they incidentally introduce
+- Structural generation changes do create explicit removed **Configuration Diff Entry** items when they eliminate non-default authored overrides
+- A **Configuration Diff** reports **Custom Naming** changes only when user-authored overrides differ
+- In auto contrast mode, a **Contrast Reference** change is the primary contrast explanation in **Configuration Diff**
+- In manual contrast mode, explicit contrast colors are the primary contrast explanation in **Configuration Diff**
+- In auto contrast mode, resolved contrast-color drift without a **Contrast Reference** change does not create a contrast **Configuration Diff Entry**
+- **Comparison Metric** and **Swatch Change Threshold** are **Comparison Settings**
+- Each **Comparison Metric** remembers its own **Swatch Change Threshold**
+- Each **Comparison Metric** has its own default **Swatch Change Threshold**
+- The default **Swatch Change Threshold** is `0.02` for `Delta E OK` and `2` for `Delta E 2000`
+- **Comparison Settings** persist locally even if the **Reference Configuration** is cleared
+- **Reset to Defaults** restores default **Comparison Settings**
+- A **Swatch Change Threshold** only affects color-only **Change Annotations**
+- A color-only difference at or above the **Swatch Change Threshold** gets a **Change Annotation**
+- A **Swatch Change Threshold** does not suppress **Configuration Diff** entries
 - A **Change Annotation** can represent a **Structural Change**, an **Accessibility-Status Change**, or a color-only difference
+- Swatch-level **Change Annotations** and quieting are emphasized on the current side, while structural markers can appear on either side when needed
+- Generation nudger changes are explained as targeted **Configuration Diff Entry** items, not opaque array summaries
+- Granular **Configuration Diff Entry** items follow the same reading order users see in the compared palettes and authored constraint list
 - A **Color-Only Difference** is still a **Change Annotation** in **Comparison View**
 - A **Structural Change** remains explicit regardless of color-difference thresholds
 - An **Accessibility-Status Change** remains explicit regardless of color-difference thresholds
@@ -58,8 +160,172 @@ _Avoid_: cosmetic change, visual-only diff
 >
 > **Dev:** "If a swatch stays AA-pass but its color shifts, is that still a **Change Annotation**?"
 > **Domain expert:** "Yes. **Accessibility-Status Change** is only one kind of annotation. Color-only differences and **Structural Changes** still count in **Comparison View**."
+>
+> **Dev:** "Should **Configuration Diff** show up as soon as a **Reference Configuration** exists?"
+> **Domain expert:** "No. **Reference View** stays focused on side-by-side reading. **Configuration Diff** belongs to **Comparison View**."
+>
+> **Dev:** "Is **Swatch Change Threshold** a percentage slider or a Delta E cutoff?"
+> **Domain expert:** "It is a raw cutoff in the selected **Comparison Metric**. It only suppresses color-only annotations, not structural or accessibility-status changes."
+>
+> **Dev:** "When I pin a **Reference Configuration**, do its constraints come with it?"
+> **Domain expert:** "Yes. Authored **Constraint** definitions are part of the **Palette Configuration**. Solve output is not."
+>
+> **Dev:** "If I clear the **Reference Configuration**, do I lose my **Comparison Metric** and **Swatch Change Threshold** too?"
+> **Domain expert:** "No. Those are local **Comparison Settings**. Clearing the baseline should not reset how the user prefers to read differences."
+>
+> **Dev:** "If several constraints change, do we just say 'constraints changed'?"
+> **Domain expert:** "No. **Configuration Diff** should use separate **Configuration Diff Entry** items so each added, removed, or edited constraint is explicit."
+>
+> **Dev:** "If a palette's auto-generated name changes because the colors changed, does that belong in **Configuration Diff**?"
+> **Domain expert:** "No. Only **Custom Naming** changes belong there. Derived labels are presentation, not authored configuration."
+>
+> **Dev:** "In auto contrast mode, do we diff the reference swatch choice or just the resulting colors?"
+> **Domain expert:** "The **Contrast Reference** change is primary because it reflects the user's authored choice. Resolved colors are supporting detail. In manual mode, the explicit colors are primary."
+>
+> **Dev:** "If I edit a constraint row in place, is that a removed rule plus an added rule?"
+> **Domain expert:** "No. An inline edit is still the same **Constraint** and should appear as a changed **Configuration Diff Entry**. Added and removed entries are for explicit row creation and deletion."
+>
+> **Dev:** "If I only disable a constraint, is that too minor for **Configuration Diff**?"
+> **Domain expert:** "No. Enabled state changes how the rule governs the palette, so it is a real **Palette Configuration** change and should be explicit in **Configuration Diff**."
+>
+> **Dev:** "What if auto contrast resolves to different colors even though the reference swatch choices stayed the same?"
+> **Domain expert:** "That is generated output drift, not a contrast configuration change. **Configuration Diff** should explain the authored generation changes, while contrast entries in auto mode stay tied to **Contrast Reference** changes."
+>
+> **Dev:** "When I switch **Comparison Metric**, should the threshold number carry over?"
+> **Domain expert:** "No. Each **Comparison Metric** should remember its own **Swatch Change Threshold** and have its own default instead of reusing a misleading numeric carryover."
+>
+> **Dev:** "What are the defaults for those two metrics?"
+> **Domain expert:** "Use `0.02` for `Delta E OK` and `2` for `Delta E 2000` so comparison uses the repo's existing threshold vocabulary."
+>
+> **Dev:** "Should **Configuration Diff** live next to the comparison controls in the sidebar?"
+> **Domain expert:** "No. Controls stay in the sidebar. **Configuration Diff** is explanatory output, so it belongs in the main **Comparison View** reading area above the side-by-side comparison."
+>
+> **Dev:** "If there are no configuration-level changes, should **Configuration Diff** disappear?"
+> **Domain expert:** "No. Keep an explicit success state so **Comparison View** still explains that there are no configuration-level differences."
+>
+> **Dev:** "Could the configs differ while the swatches still stay quiet under the threshold?"
+> **Domain expert:** "Yes. `Swatch Change Threshold` only affects color-only swatch annotations. **Configuration Diff** still reports configuration differences even when the comparison view shows no threshold-crossing swatch chips."
+>
+> **Dev:** "If gamut mapping is a shared inspection lens, should changing it after pinning affect only the current side?"
+> **Domain expert:** "No. **Shared Inspection Settings** apply symmetrically while reading the comparison. They are excluded from **Configuration Diff** because they are part of the viewing lens, not authored differences."
+>
+> **Dev:** "If they are a shared lens, do those settings still get frozen into the **Reference Configuration**?"
+> **Domain expert:** "No. **Reference Configuration** captures the authored baseline, not the shared inspection lens."
+>
+> **Dev:** "Should every swatch chip appear on both sides?"
+> **Domain expert:** "No. Swatch-level emphasis belongs on the current side so the editable result stays action-oriented. Structural markers can still appear on either side when the compared structure itself differs."
+>
+> **Dev:** "If clearing the reference keeps my comparison preferences, what about a full reset?"
+> **Domain expert:** "A full **Reset to Defaults** is stronger. It should restore the default palette configuration and the default **Comparison Settings**."
+>
+> **Dev:** "What about switching from WCAG 2.2 to APCA after pinning?"
+> **Domain expert:** "That changes the shared inspection lens, not the authored baseline. **Contrast Algorithm** should be applied symmetrically while reading both sides, not frozen into the **Reference Configuration**."
+>
+> **Dev:** "If I tweak one neutral step or one palette hue, can **Configuration Diff** just say 'adjustments changed'?"
+> **Domain expert:** "No. Generation nudgers should be explained as targeted **Configuration Diff Entry** items so the affected step or palette is explicit."
+>
+> **Dev:** "If I pin while **Theme Preference** is `auto`, should the baseline keep following future OS theme changes?"
+> **Domain expert:** "No. The authored **Theme Preference** remains `auto`, but the **Reference Configuration** also freezes the **Resolved Theme** used to generate that baseline so it does not drift later."
+>
+> **Dev:** "When I restore that reference later, should `auto` immediately follow the current OS theme again?"
+> **Domain expert:** "No. Restore should reproduce the pinned baseline exactly, including its frozen **Resolved Theme**, or the current side would still differ right after restore."
+>
+> **Dev:** "If both sides still say `auto` but they resolve differently later, does that become a theme diff?"
+> **Domain expert:** "No. The authored **Theme Preference** still matches, so **Configuration Diff** stays silent. That is output drift from different **Resolved Theme** values, not an authored configuration change."
+>
+> **Dev:** "What if the authored theme changes from `auto` to `light`, but the palette output happens to look the same right now?"
+> **Domain expert:** "That is still a real **Theme Preference** change and belongs in **Configuration Diff**. Temporary output equality does not erase an authored configuration change."
+>
+> **Dev:** "Even though the Theme control lives with display settings in the UI, where does it belong in the diff?"
+> **Domain expert:** "In the generation portion of **Configuration Diff**. Its current control placement is incidental; its domain effect is palette generation."
+>
+> **Dev:** "If a theme diff involves `auto`, should the entry just say `Auto → Light`?"
+> **Domain expert:** "No. Keep the authored **Theme Preference** primary, but include the frozen **Resolved Theme** as supporting detail when `auto` is involved so the baseline remains legible."
+>
+> **Dev:** "Should the drift note be generic, or should it say which themes are involved?"
+> **Domain expert:** "Name both. A **Resolved Theme Drift** note should say how the current `auto` theme resolves now and which **Resolved Theme** the pinned baseline was generated with."
+>
+> **Dev:** "When exactly does that note appear?"
+> **Domain expert:** "Only when both sides still use authored `auto` **Theme Preference** values and their **Resolved Theme** values differ. If the authored theme changed, explain that through **Configuration Diff** instead."
+>
+> **Dev:** "If that drift note is the only explanation, should the diff success state disappear?"
+> **Domain expert:** "No. Keep the drift note and still show the explicit **Configuration Diff** success state. One explains output drift; the other confirms there are no authored configuration changes."
+>
+> **Dev:** "If something exists on only one side, should the diff say `none → value`?"
+> **Domain expert:** "No. Use explicit add/remove language. A real addition or removal should read like an action, not like an awkward empty-value comparison."
+>
+> **Dev:** "If increasing the step count creates new nudger slots that are still at their default values, should those show up as added diff entries?"
+> **Domain expert:** "No. Those untouched defaults are just fallout from the structural change. Show the step-count change itself, not a pile of incidental zero-valued additions."
+>
+> **Dev:** "What if shrinking the structure removes a slot that had a real authored override?"
+> **Domain expert:** "Then show it. If a structural shrink deletes a non-default authored override, that removal belongs in **Configuration Diff** alongside the count change."
+>
+> **Dev:** "If the configs still match, why are the swatches different?"
+> **Domain expert:** "That is **Resolved Theme Drift**. The authored **Theme Preference** is still the same, but the current `auto` theme resolved differently from the frozen baseline."
+>
+> **Dev:** "What if there is also a real base-color change at the same time?"
+> **Domain expert:** "Keep the **Resolved Theme Drift** note anyway. It explains a separate source of output difference that **Configuration Diff** should not misclassify as an authored change."
+>
+> **Dev:** "Should we generalize that into some broader environment-drift term now?"
+> **Domain expert:** "No. Keep it theme-specific until the product actually has another real class of non-authored output drift."
+>
+> **Dev:** "Should that note also show up in the quieter side-by-side view?"
+> **Domain expert:** "No. It belongs to **Comparison View** because it explains why the sides differ. **Reference View** stays the quieter baseline."
+>
+> **Dev:** "If that note exists, should it come before or after **Configuration Diff**?"
+> **Domain expert:** "Put it first. **Resolved Theme Drift** is the broader caveat about why output differs, and **Configuration Diff** should be read within that frame."
+>
+> **Dev:** "Once the diff is granular, how should those entries be ordered?"
+> **Domain expert:** "Use the same reading order users already see in the compared palettes and authored constraint list so the explanation lines up with the rest of the interface."
+>
+> **Dev:** "If a color-only difference lands exactly on the **Swatch Change Threshold**, does it stay quiet?"
+> **Domain expert:** "No. The threshold is the minimum qualifying difference, so an exact-threshold match still gets a **Change Annotation**."
+>
+> **Dev:** "When a **Configuration Diff Entry** shows values, which direction should it read?"
+> **Domain expert:** "Read from **Reference Configuration** to **Current Palette Configuration** so the baseline comes first and the edited result comes second."
 
 ## Flagged ambiguities
 
 - "comparison" was being used to mean both the overall baseline workflow and the specific annotated mode — resolved: use **Reference View** for the default side-by-side state and **Comparison View** for the explicit difference-emphasizing state
 - "baseline" and "reference" were being used interchangeably — resolved: use **Reference Configuration** as the canonical term
+- "configuration diff" could have been read as a general reference-workspace summary — resolved: it is a **Comparison View** explanation, not a **Reference View** default element
+- "swatch change threshold" could have been read as a normalized percentage — resolved: it is a raw cutoff in the selected **Comparison Metric**
+- "constraints" could have been read as solver artifacts instead of authored rules — resolved: authored **Constraint** definitions belong to the **Palette Configuration**; solve output does not
+- "comparison settings" could have been read as part of the pinned baseline — resolved: they are local preferences that survive clearing the **Reference Configuration**
+- "configuration diff" could have been implemented as category-level blobs — resolved: it should explain changes through individual **Configuration Diff Entry** items
+- "configuration diff placement" could have drifted into the sidebar with controls — resolved: it belongs in the main **Comparison View** reading area
+- "no configuration changes" could have hidden the entire **Configuration Diff** surface — resolved: keep an explicit success state
+- "naming changes" could have included derived palette labels — resolved: only **Custom Naming** changes belong in **Configuration Diff**
+- "contrast settings and references" could have collapsed authored reference changes into resolved colors — resolved: auto mode explains **Contrast Reference** changes primarily; manual mode explains explicit colors
+- "constraint changes" could have reported inline edits as remove-and-add churn — resolved: inline edits are changed entries; add/remove is reserved for explicit row creation or deletion
+- "disabled constraints" could have been treated as cosmetic UI state — resolved: enabled state is part of the authored **Palette Configuration** and belongs in **Configuration Diff**
+- "theme" could have drifted into the shared viewing lens — resolved: **Theme Preference** remains part of the authored **Palette Configuration**
+- "`auto` theme" could have left the pinned baseline drifting with future system theme changes — resolved: a pinned **Reference Configuration** freezes the **Resolved Theme** used at pin time
+- "restore reference" could have reapplied authored `auto` semantics instead of the frozen baseline — resolved: restore reproduces the pinned **Resolved Theme** exactly
+- "same `auto` preference" could have been misreported as a theme configuration change when the environment resolved it differently — resolved: that is not a **Configuration Diff** entry
+- "same output" could have been mistaken for "no theme configuration change" — resolved: authored **Theme Preference** changes still belong in **Configuration Diff**
+- "theme" could have followed its current UI placement into inspection-oriented diff categories — resolved: **Theme Preference** belongs with generation changes
+- "`auto` theme" could have made diff entries too abstract to interpret — resolved: include **Resolved Theme** as supporting detail when needed
+- "theme drift note" could have been too vague to trust — resolved: explicitly name the current and pinned **Resolved Theme** values
+- "theme drift note" could have triggered for ordinary authored theme changes — resolved: it appears only for matching authored `auto` preferences with differing **Resolved Theme** values
+- "theme drift only" could have suppressed the diff success state — resolved: keep both explanations visible
+- "one-sided diff entries" could have fallen back to empty-value serialization — resolved: use explicit add/remove language
+- "structural additions" could have exploded into noise from untouched default slots — resolved: suppress incidental default-valued additions
+- "structural shrink" could have hidden real authored overrides that disappeared with it — resolved: show explicit removals for non-default authored overrides
+- "same authored theme" could have been mistaken for identical generated output — resolved: **Resolved Theme Drift** can still create comparison differences
+- "theme drift note" could have been hidden when real config changes also existed — resolved: keep the note visible because it explains a separate cause
+- "environment drift" could have been generalized too early — resolved: keep **Resolved Theme Drift** theme-specific for now
+- "theme drift note" could have leaked into the baseline side-by-side mode — resolved: keep it in **Comparison View** only
+- "theme drift note" could have been buried after **Configuration Diff** — resolved: place it above the diff as the broader explanation
+- "auto contrast color drift" could have been mistaken for authored contrast configuration change — resolved: without a **Contrast Reference** change, it is generated output drift, not a contrast **Configuration Diff** entry
+- "metric switching" could have reused one threshold number across incompatible scales — resolved: each **Comparison Metric** remembers its own threshold and has its own default
+- "no visible swatch changes" could have been mistaken for "no configuration changes" — resolved: threshold quietness and **Configuration Diff** are separate explanations
+- "shared inspection settings" could have created one-sided comparison outcomes after pinning — resolved: they are a symmetric viewing lens, not authored differences
+- "shared inspection settings" could have leaked into the pinned baseline — resolved: they are excluded from the **Reference Configuration**
+- "comparison emphasis" could have duplicated every swatch chip on both sides — resolved: swatch-level emphasis stays on the current side; structural markers remain bilateral when needed
+- "contrast algorithm" could have been treated as a frozen authored difference instead of a shared reading lens — resolved: it is a **Shared Inspection Setting**
+- "generation adjustments" could have collapsed into array-level blobs — resolved: nudger changes should be explained as targeted **Configuration Diff Entry** items
+- "reset behavior" could have followed the same rule as clearing the reference — resolved: **Reset to Defaults** restores default **Comparison Settings**
+- "granular diff ordering" could have become an arbitrary log order — resolved: keep the interface reading order
+- "threshold equality" could have fallen through the gap between changed and quiet — resolved: equality counts as meeting the minimum qualifying difference
+- "diff direction" could have reversed baseline and edited values — resolved: show **Reference Configuration** first, then **Current Palette Configuration**

--- a/src/lib/comparisonDiff.spec.ts
+++ b/src/lib/comparisonDiff.spec.ts
@@ -1,309 +1,400 @@
 import { describe, expect, it } from 'vitest';
+
 import { diffColorStates } from './comparisonDiff';
 
-/**
- * Test suite for Configuration Diff generation.
- *
- * Tests focus on:
- * - Detecting changes in generation settings
- * - Detecting changes in contrast settings
- * - Detecting changes in custom naming
- * - Excluding inspection-only settings from diff
- * - Comprehensive diff output suitable for presentation
- */
+function createConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    numColors: 11,
+    numPalettes: 11,
+    baseColor: '#5EF784',
+    warmth: -7,
+    warmthHue: 142,
+    x1: 0.16,
+    y1: 0,
+    x2: 0.28,
+    y2: 0.38,
+    chromaMultiplier: 1,
+    lightnessNudgers: Array.from({ length: 11 }, () => 0),
+    hueNudgers: Array.from({ length: 11 }, () => 0),
+    stepSaturationNudgers: Array.from({ length: 11 }, () => 0),
+    paletteSaturationNudgers: Array.from({ length: 11 }, () => 0),
+    paletteChromaNudgers: Array.from({ length: 11 }, () => 1),
+    contrastMode: 'auto',
+    lowStep: 0,
+    highStep: 10,
+    lowReference: { kind: 'neutral', stepIndex: 0 },
+    highReference: { kind: 'neutral', stepIndex: 10 },
+    contrast: { low: '#ffffff', high: '#000000' },
+    solveAdjacentStopLows: true,
+    themePreference: 'auto',
+    currentTheme: 'light',
+    customNeutralName: undefined,
+    customPaletteNames: undefined,
+    constraints: [],
+    displayColorSpace: 'hex',
+    gamutSpace: 'srgb',
+    swatchLabels: 'both',
+    showSwatchGamutWarnings: true,
+    showSwatchContrastIndicators: true,
+    swatchContrastIndicators: {
+      wcagThreeToOne: true,
+      wcagAA: true,
+      wcagAAA: true,
+      apcaLarge: true,
+      apcaFluent: true,
+      apcaBody: true
+    },
+    contrastAlgorithm: 'WCAG',
+    cvdMode: 'none',
+    ...overrides
+  };
+}
 
 describe('comparisonDiff', () => {
-  describe('diffColorStates', () => {
-    it('identifies no changes when configurations are identical', () => {
-      const config = {
-        numColors: 11,
-        numPalettes: 11,
-        baseColor: '#5EF784',
-        warmth: -7,
-        x1: 0.16,
-        y1: 0.0,
-        x2: 0.28,
-        y2: 0.38,
-        chromaMultiplier: 1,
-        contrastMode: 'auto' as const,
-        lowStep: 0,
-        highStep: 10,
-        contrast: { low: '#ffffff', high: '#000000' }
-      };
-
-      const diff = diffColorStates(config, config);
-
-      expect(diff.hasChanges).toBe(false);
-      expect(diff.generationChanges).toHaveLength(0);
-      expect(diff.contrastChanges).toHaveLength(0);
-      expect(diff.namingChanges).toHaveLength(0);
+  it('ignores shared inspection changes and resolved auto-theme drift when authored configuration matches', () => {
+    const reference = createConfig({
+      displayColorSpace: 'oklch',
+      gamutSpace: 'p3',
+      swatchLabels: 'none',
+      contrastAlgorithm: 'APCA',
+      cvdMode: 'deuteranopia',
+      currentTheme: 'light',
+      resolvedTheme: 'light'
+    });
+    const current = createConfig({
+      displayColorSpace: 'hex',
+      gamutSpace: 'srgb',
+      swatchLabels: 'both',
+      contrastAlgorithm: 'WCAG',
+      cvdMode: 'none',
+      currentTheme: 'dark'
     });
 
-    it('detects generation setting changes', () => {
-      const current = {
-        numColors: 11,
-        numPalettes: 11,
-        baseColor: '#5EF784',
-        warmth: -7,
-        x1: 0.16,
-        y1: 0.0,
-        x2: 0.28,
-        y2: 0.38,
-        chromaMultiplier: 1,
-        contrastMode: 'auto' as const,
-        lowStep: 0,
-        highStep: 10,
-        contrast: { low: '#ffffff', high: '#000000' }
-      };
+    const diff = diffColorStates(current, reference);
 
-      const reference = {
-        ...current,
-        numColors: 13,
-        baseColor: '#00ff00'
-      };
-
-      const diff = diffColorStates(current, reference);
-
-      expect(diff.hasChanges).toBe(true);
-      expect(diff.generationChanges.length).toBeGreaterThan(0);
-    });
-
-    it('detects contrast mode changes', () => {
-      const current = {
-        numColors: 11,
-        numPalettes: 11,
-        baseColor: '#5EF784',
-        warmth: -7,
-        x1: 0.16,
-        y1: 0.0,
-        x2: 0.28,
-        y2: 0.38,
-        chromaMultiplier: 1,
-        contrastMode: 'auto' as const,
-        lowStep: 0,
-        highStep: 10,
-        contrast: { low: '#ffffff', high: '#000000' }
-      };
-
-      const reference = {
-        ...current,
-        contrastMode: 'manual' as const,
-        contrast: { low: '#ff0000', high: '#00ff00' }
-      };
-
-      const diff = diffColorStates(current, reference);
-
-      expect(diff.hasChanges).toBe(true);
-      expect(diff.contrastChanges.length).toBeGreaterThan(0);
-    });
-
-    it('detects custom naming changes', () => {
-      const current = {
-        numColors: 11,
-        numPalettes: 11,
-        baseColor: '#5EF784',
-        warmth: -7,
-        x1: 0.16,
-        y1: 0.0,
-        x2: 0.28,
-        y2: 0.38,
-        chromaMultiplier: 1,
-        contrastMode: 'auto' as const,
-        lowStep: 0,
-        highStep: 10,
-        contrast: { low: '#ffffff', high: '#000000' },
-        customNeutralName: 'Gray'
-      };
-
-      const reference = {
-        ...current,
-        customNeutralName: 'Neutrals'
-      };
-
-      const diff = diffColorStates(current, reference);
-
-      expect(diff.hasChanges).toBe(true);
-      expect(diff.namingChanges.length).toBeGreaterThan(0);
-    });
-
-    it('excludes inspection settings from diff', () => {
-      const current = {
-        numColors: 11,
-        numPalettes: 11,
-        baseColor: '#5EF784',
-        warmth: -7,
-        x1: 0.16,
-        y1: 0.0,
-        x2: 0.28,
-        y2: 0.38,
-        chromaMultiplier: 1,
-        contrastMode: 'auto' as const,
-        lowStep: 0,
-        highStep: 10,
-        contrast: { low: '#ffffff', high: '#000000' },
-        displayColorSpace: 'hex' as const,
-        cvdMode: 'none' as const
-      };
-
-      const reference = {
-        ...current,
-        displayColorSpace: 'oklch' as const,
-        cvdMode: 'protanopia' as const
-      };
-
-      const diff = diffColorStates(current, reference);
-
-      // Display color space and CVD mode are inspection settings, should not appear in diff
-      expect(diff.hasChanges).toBe(false);
-      expect(diff.generationChanges).toHaveLength(0);
-      expect(diff.contrastChanges).toHaveLength(0);
-    });
-
-    it('returns structured diff suitable for presentation', () => {
-      const current = {
-        numColors: 11,
-        numPalettes: 11,
-        baseColor: '#5EF784',
-        warmth: -7,
-        x1: 0.16,
-        y1: 0.0,
-        x2: 0.28,
-        y2: 0.38,
-        chromaMultiplier: 1,
-        contrastMode: 'auto' as const,
-        lowStep: 0,
-        highStep: 10,
-        contrast: { low: '#ffffff', high: '#000000' }
-      };
-
-      const reference = {
-        ...current,
-        numColors: 9,
-        warmth: 5
-      };
-
-      const diff = diffColorStates(current, reference);
-
-      expect(diff).toHaveProperty('hasChanges');
-      expect(diff).toHaveProperty('generationChanges');
-      expect(diff).toHaveProperty('contrastChanges');
-      expect(diff).toHaveProperty('namingChanges');
-      expect(diff).toHaveProperty('timestamp');
-    });
+    expect(diff.hasChanges).toBe(false);
+    expect(diff.generationChanges).toHaveLength(0);
+    expect(diff.contrastChanges).toHaveLength(0);
+    expect(diff.constraintChanges).toHaveLength(0);
+    expect(diff.namingChanges).toHaveLength(0);
   });
 
-  describe('diff categorization', () => {
-    it('correctly categorizes step count changes', () => {
-      const current = {
-        numColors: 13,
-        numPalettes: 11,
-        baseColor: '#5EF784',
-        warmth: -7,
-        x1: 0.16,
-        y1: 0.0,
-        x2: 0.28,
-        y2: 0.38,
-        chromaMultiplier: 1,
-        contrastMode: 'auto' as const,
-        lowStep: 0,
-        highStep: 10,
-        contrast: { low: '#ffffff', high: '#000000' }
-      };
-
-      const reference = {
-        ...current,
-        numColors: 11
-      };
-
-      const diff = diffColorStates(current, reference);
-
-      expect(diff.hasChanges).toBe(true);
-      const generationChange = diff.generationChanges.find(
-        (c) => c.label.includes('color') || c.label.includes('step')
-      );
-      expect(generationChange).toBeDefined();
+  it('reports theme preference as a generation change and includes resolved theme detail for auto', () => {
+    const reference = createConfig({
+      themePreference: 'auto',
+      resolvedTheme: 'light'
+    });
+    const current = createConfig({
+      themePreference: 'light',
+      currentTheme: 'light'
     });
 
-    it('correctly categorizes palette count changes', () => {
-      const current = {
-        numColors: 11,
-        numPalettes: 13,
-        baseColor: '#5EF784',
-        warmth: -7,
-        x1: 0.16,
-        y1: 0.0,
-        x2: 0.28,
-        y2: 0.38,
-        chromaMultiplier: 1,
-        contrastMode: 'auto' as const,
-        lowStep: 0,
-        highStep: 10,
-        contrast: { low: '#ffffff', high: '#000000' }
-      };
+    const diff = diffColorStates(current, reference);
 
-      const reference = {
-        ...current,
-        numPalettes: 11
-      };
-
-      const diff = diffColorStates(current, reference);
-
-      expect(diff.hasChanges).toBe(true);
-      const generationChange = diff.generationChanges.find((c) => c.label.includes('palette'));
-      expect(generationChange).toBeDefined();
-    });
+    expect(diff.generationChanges).toContainEqual(
+      expect.objectContaining({
+        field: 'themePreference',
+        label: 'Theme',
+        kind: 'changed',
+        referenceValue: 'Auto (resolved Light)',
+        currentValue: 'Light'
+      })
+    );
   });
 
-  describe('contrast field completeness', () => {
-    const fullConfig = {
-      numColors: 11,
-      numPalettes: 11,
-      baseColor: '#5EF784',
-      warmth: -7,
+  it('ignores preset-backed generation and auto-reference drift when both sides are still authored auto', () => {
+    const reference = createConfig({
+      themePreference: 'auto',
+      resolvedTheme: 'light',
+      currentTheme: 'light',
       x1: 0.16,
-      y1: 0.0,
+      y1: 0,
       x2: 0.28,
       y2: 0.38,
       chromaMultiplier: 1,
-      contrastMode: 'auto' as const,
-      lowStep: 0,
-      highStep: 10,
+      lowReference: { kind: 'neutral', stepIndex: 0 },
+      highReference: { kind: 'neutral', stepIndex: 10 }
+    });
+    const current = createConfig({
+      themePreference: 'auto',
+      currentTheme: 'dark',
+      x1: 0.45,
+      y1: 0.08,
+      x2: 0.77,
+      y2: 0.96,
+      chromaMultiplier: 0.83,
+      lowReference: { kind: 'neutral', stepIndex: 2 },
+      highReference: { kind: 'neutral', stepIndex: 10 }
+    });
+
+    const diff = diffColorStates(current, reference);
+
+    expect(diff.hasChanges).toBe(false);
+    expect(diff.generationChanges).toHaveLength(0);
+    expect(diff.contrastChanges).toHaveLength(0);
+  });
+
+  it('uses contrast references in auto mode and ignores resolved contrast-color drift alone', () => {
+    const reference = createConfig({
+      contrastMode: 'auto',
       lowReference: { kind: 'neutral', stepIndex: 0 },
       highReference: { kind: 'neutral', stepIndex: 10 },
-      contrast: { low: '#ffffff', high: '#000000' },
-      contrastAlgorithm: 'WCAG' as const,
-      solveAdjacentStopLows: true
-    };
-
-    it('does not report contrast fields as changed when both sides are identical', () => {
-      expect.assertions(2);
-      const diff = diffColorStates(fullConfig, fullConfig);
-      expect(diff.hasChanges).toBe(false);
-      expect(diff.contrastChanges).toHaveLength(0);
+      contrast: { low: '#ffffff', high: '#000000' }
+    });
+    const current = createConfig({
+      contrastMode: 'auto',
+      lowReference: { kind: 'neutral', stepIndex: 0 },
+      highReference: { kind: 'neutral', stepIndex: 10 },
+      contrast: { low: '#fefefe', high: '#010101' }
     });
 
-    it('reports contrastMode as changed when it differs', () => {
-      expect.assertions(2);
-      const diff = diffColorStates({ ...fullConfig, contrastMode: 'manual' as const }, fullConfig);
-      expect(diff.hasChanges).toBe(true);
-      expect(diff.contrastChanges.some((c) => c.field === 'contrastMode')).toBe(true);
+    const driftOnly = diffColorStates(current, reference);
+    expect(driftOnly.contrastChanges).toHaveLength(0);
+
+    const withReferenceChange = diffColorStates(
+      createConfig({
+        lowReference: { kind: 'neutral', stepIndex: 2 }
+      }),
+      reference
+    );
+
+    expect(withReferenceChange.contrastChanges).toContainEqual(
+      expect.objectContaining({
+        field: 'lowReference',
+        label: 'Low contrast reference',
+        kind: 'changed',
+        referenceValue: 'Neutral, step 0',
+        currentValue: 'Neutral, step 20'
+      })
+    );
+  });
+
+  it('reports manual contrast colors individually', () => {
+    const reference = createConfig({
+      contrastMode: 'manual',
+      contrast: { low: '#111111', high: '#eeeeee' }
+    });
+    const current = createConfig({
+      contrastMode: 'manual',
+      contrast: { low: '#222222', high: '#eeeeee' }
     });
 
-    it('reports lowReference as changed when it differs', () => {
-      expect.assertions(2);
-      const diff = diffColorStates(
-        { ...fullConfig, lowReference: { kind: 'neutral', stepIndex: 2 } },
-        fullConfig
-      );
-      expect(diff.hasChanges).toBe(true);
-      expect(diff.contrastChanges.some((c) => c.field === 'lowReference')).toBe(true);
+    const diff = diffColorStates(current, reference);
+
+    expect(diff.contrastChanges).toContainEqual(
+      expect.objectContaining({
+        field: 'contrast.low',
+        label: 'Low contrast color',
+        kind: 'changed',
+        referenceValue: '#111111',
+        currentValue: '#222222'
+      })
+    );
+  });
+
+  it('explains constraint edits, additions, and removals as individual entries', () => {
+    const reference = createConfig({
+      constraints: [
+        {
+          id: 'target-1',
+          type: 'target-color',
+          enabled: true,
+          targetHex: '#5EF784',
+          metric: 'ok'
+        },
+        {
+          id: 'rule-1',
+          type: 'contrast-rule',
+          enabled: true,
+          scope: 'neutral',
+          stepIndex: 4,
+          reference: 'low',
+          algorithm: 'WCAG',
+          level: 'wcagAA'
+        }
+      ]
+    });
+    const current = createConfig({
+      constraints: [
+        {
+          id: 'target-1',
+          type: 'target-color',
+          enabled: false,
+          targetHex: '#00FF00',
+          metric: 'ok'
+        },
+        {
+          id: 'rule-2',
+          type: 'contrast-rule',
+          enabled: true,
+          scope: 'all-palettes',
+          stepIndex: 4,
+          reference: 'low',
+          algorithm: 'APCA',
+          level: 'apcaBody'
+        }
+      ]
     });
 
-    it('reports solveAdjacentStopLows as changed when it differs', () => {
-      expect.assertions(2);
-      const diff = diffColorStates({ ...fullConfig, solveAdjacentStopLows: false }, fullConfig);
-      expect(diff.hasChanges).toBe(true);
-      expect(diff.contrastChanges.some((c) => c.field === 'solveAdjacentStopLows')).toBe(true);
+    const diff = diffColorStates(current, reference);
+
+    expect(diff.constraintChanges).toContainEqual(
+      expect.objectContaining({
+        kind: 'changed',
+        referenceValue: '#5EF784 · ΔEOK',
+        currentValue: '#00FF00 · ΔEOK · Disabled'
+      })
+    );
+    expect(diff.constraintChanges).toContainEqual(
+      expect.objectContaining({
+        kind: 'removed',
+        referenceValue: 'Neutral · Step 40 · Low ref · WCAG AA'
+      })
+    );
+    expect(diff.constraintChanges).toContainEqual(
+      expect.objectContaining({
+        kind: 'added',
+        currentValue: 'All palettes · Step 40 · Low ref · APCA Body'
+      })
+    );
+  });
+
+  it('keeps constraint diff entries in authored order when removals and additions are mixed', () => {
+    const reference = createConfig({
+      constraints: [
+        {
+          id: 'rule-1',
+          type: 'contrast-rule',
+          enabled: true,
+          scope: 'neutral',
+          stepIndex: 1,
+          reference: 'low',
+          algorithm: 'WCAG',
+          level: 'wcagAA'
+        },
+        {
+          id: 'rule-2',
+          type: 'contrast-rule',
+          enabled: true,
+          scope: 'neutral',
+          stepIndex: 2,
+          reference: 'low',
+          algorithm: 'WCAG',
+          level: 'wcagAA'
+        },
+        {
+          id: 'rule-3',
+          type: 'contrast-rule',
+          enabled: true,
+          scope: 'neutral',
+          stepIndex: 3,
+          reference: 'low',
+          algorithm: 'WCAG',
+          level: 'wcagAA'
+        }
+      ]
     });
+    const current = createConfig({
+      constraints: [
+        {
+          id: 'rule-1',
+          type: 'contrast-rule',
+          enabled: false,
+          scope: 'neutral',
+          stepIndex: 1,
+          reference: 'low',
+          algorithm: 'WCAG',
+          level: 'wcagAA'
+        },
+        {
+          id: 'rule-3',
+          type: 'contrast-rule',
+          enabled: false,
+          scope: 'neutral',
+          stepIndex: 3,
+          reference: 'low',
+          algorithm: 'WCAG',
+          level: 'wcagAA'
+        },
+        {
+          id: 'rule-4',
+          type: 'contrast-rule',
+          enabled: true,
+          scope: 'all-palettes',
+          stepIndex: 4,
+          reference: 'high',
+          algorithm: 'APCA',
+          level: 'apcaBody'
+        }
+      ]
+    });
+
+    const diff = diffColorStates(current, reference);
+
+    expect(diff.constraintChanges.map((entry) => `${entry.field}:${entry.kind}`)).toEqual([
+      'constraint.rule-1:changed',
+      'constraint.rule-2:removed',
+      'constraint.rule-3:changed',
+      'constraint.rule-4:added'
+    ]);
+  });
+
+  it('suppresses incidental default additions from structural growth', () => {
+    const reference = createConfig({
+      numColors: 11,
+      lightnessNudgers: Array.from({ length: 11 }, () => 0)
+    });
+    const current = createConfig({
+      numColors: 13,
+      lightnessNudgers: Array.from({ length: 13 }, () => 0)
+    });
+
+    const diff = diffColorStates(current, reference);
+
+    expect(diff.generationChanges).toContainEqual(
+      expect.objectContaining({
+        field: 'numColors',
+        label: 'Number of steps'
+      })
+    );
+    expect(
+      diff.generationChanges.some((entry) => entry.label.includes('lightness adjustment'))
+    ).toBe(false);
+  });
+
+  it('keeps removed non-default authored overrides visible when structure shrinks', () => {
+    const reference = createConfig({
+      numPalettes: 3,
+      hueNudgers: [0, 0, 15],
+      customPaletteNames: ['', '', 'Accent']
+    });
+    const current = createConfig({
+      numPalettes: 2,
+      hueNudgers: [0, 0],
+      customPaletteNames: ['', '']
+    });
+
+    const diff = diffColorStates(current, reference);
+
+    expect(diff.generationChanges).toContainEqual(
+      expect.objectContaining({
+        field: 'numPalettes',
+        label: 'Number of palettes'
+      })
+    );
+    expect(diff.generationChanges).toContainEqual(
+      expect.objectContaining({
+        kind: 'removed',
+        label: 'Palette 3 hue adjustment',
+        referenceValue: '15'
+      })
+    );
+    expect(diff.namingChanges).toContainEqual(
+      expect.objectContaining({
+        kind: 'removed',
+        label: 'Palette 3 name',
+        referenceValue: 'Accent'
+      })
+    );
   });
 });

--- a/src/lib/comparisonDiff.ts
+++ b/src/lib/comparisonDiff.ts
@@ -1,79 +1,35 @@
-/**
- * Configuration Diff generation for Reference View.
- *
- * Compares current and reference Palette Configurations and produces
- * a structured diff focused on design-relevant changes:
- * - Generation settings (numColors, numPalettes, baseColor, warmth, etc.)
- * - Contrast settings (mode, low/high reference, manual colors)
- * - Custom naming (neutral and palette-specific)
- *
- * Excludes inspection-only settings:
- * - displayColorSpace, gamutSpace, themePreference
- * - swatchLabels, showSwatchGamutWarnings, showSwatchContrastIndicators
- * - cvdMode, theme preference
- *
- * Results are structured for presentation in Configuration Diff UI.
- */
+import { getConstraintThresholdLabel, getTargetColorMetricLabel } from '$lib/constraintUtils';
+import { normalizeCustomPaletteName, normalizeCustomPaletteNames } from '$lib/paletteNameUtils';
+import { themePresets } from '$lib/themePresets';
+import type {
+  ColorDifferenceMetric,
+  Constraint,
+  ConstraintThresholdKey,
+  ContrastAlgorithm,
+  ContrastReference
+} from '$lib/types';
 
-/**
- * A single change entry in the configuration diff
- */
 export interface DiffEntry {
   field: string;
   label: string;
-  currentValue: unknown;
-  referenceValue: unknown;
+  kind: 'changed' | 'added' | 'removed';
+  referenceValue?: string;
+  currentValue?: string;
 }
 
-/**
- * Structured configuration diff result
- */
 export interface ConfigurationDiff {
   hasChanges: boolean;
   generationChanges: DiffEntry[];
   contrastChanges: DiffEntry[];
+  constraintChanges: DiffEntry[];
   namingChanges: DiffEntry[];
   timestamp: number;
 }
 
-/**
- * Fields that are part of the design-relevant configuration
- */
-const GENERATION_FIELDS = [
-  'numColors',
-  'numPalettes',
-  'baseColor',
-  'warmth',
-  'warmthHue',
-  'x1',
-  'y1',
-  'x2',
-  'y2',
-  'chromaMultiplier',
-  'lightnessNudgers',
-  'hueNudgers',
-  'stepSaturationNudgers',
-  'paletteSaturationNudgers',
-  'paletteChromaNudgers'
-];
+const DEFAULT_NUM_COLORS = 11;
+const DEFAULT_NUM_PALETTES = 11;
 
-const CONTRAST_FIELDS = [
-  'contrastMode',
-  'lowStep',
-  'highStep',
-  'lowReference',
-  'highReference',
-  'contrast',
-  'contrastAlgorithm',
-  'solveAdjacentStopLows'
-];
-
-const NAMING_FIELDS = ['customNeutralName', 'customPaletteNames'];
-
-/**
- * Friendly labels for field names in the diff output
- */
-const FIELD_LABELS: Record<string, string> = {
+const GENERATION_FIELD_LABELS: Record<string, string> = {
   numColors: 'Number of steps',
   numPalettes: 'Number of palettes',
   baseColor: 'Base color',
@@ -84,116 +40,663 @@ const FIELD_LABELS: Record<string, string> = {
   x2: 'High contrast X',
   y2: 'High contrast Y',
   chromaMultiplier: 'Chroma multiplier',
-  lightnessNudgers: 'Lightness adjustments',
-  hueNudgers: 'Hue adjustments',
-  stepSaturationNudgers: 'Step saturation adjustments',
-  paletteSaturationNudgers: 'Palette saturation adjustments',
-  paletteChromaNudgers: 'Palette chroma adjustments',
-  contrastMode: 'Contrast mode',
-  lowStep: 'Low contrast step',
-  highStep: 'High contrast step',
-  lowReference: 'Low contrast reference',
-  highReference: 'High contrast reference',
-  contrast: 'Contrast colors',
-  contrastAlgorithm: 'Contrast algorithm',
-  solveAdjacentStopLows: 'Solve adjacent stops',
-  customNeutralName: 'Neutral palette name',
-  customPaletteNames: 'Palette names'
+  themePreference: 'Theme'
 };
 
-/**
- * Helper to check if two values are deeply equal
- */
+const THEME_PRESET_BACKED_GENERATION_FIELDS = new Set([
+  'numColors',
+  'numPalettes',
+  'baseColor',
+  'warmth',
+  'x1',
+  'y1',
+  'x2',
+  'y2',
+  'chromaMultiplier'
+]);
+
 function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function asString(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  return JSON.stringify(value);
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function asNumberArray(value: unknown): number[] {
+  return Array.isArray(value)
+    ? value.map((entry) => (typeof entry === 'number' && Number.isFinite(entry) ? entry : 0))
+    : [];
+}
+
+function asConstraints(value: unknown): Constraint[] {
+  return Array.isArray(value) ? (value as Constraint[]) : [];
+}
+
+function createChangedEntry(
+  field: string,
+  label: string,
+  currentValue: unknown,
+  referenceValue: unknown
+): DiffEntry {
+  return {
+    field,
+    label,
+    kind: 'changed',
+    referenceValue: asString(referenceValue),
+    currentValue: asString(currentValue)
+  };
+}
+
+function createOneSidedEntry(
+  kind: 'added' | 'removed',
+  field: string,
+  label: string,
+  value: unknown
+): DiffEntry {
+  return kind === 'added'
+    ? {
+        field,
+        label,
+        kind,
+        currentValue: asString(value)
+      }
+    : {
+        field,
+        label,
+        kind,
+        referenceValue: asString(value)
+      };
+}
+
+function titleCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function getResolvedTheme(config: Record<string, unknown>): 'light' | 'dark' | undefined {
+  const theme = config.resolvedTheme ?? config.currentTheme;
+  return theme === 'light' || theme === 'dark' ? theme : undefined;
+}
+
+function isPureResolvedThemeDrift(
+  current: Record<string, unknown>,
+  reference: Record<string, unknown>
+): boolean {
+  return (
+    current.themePreference === 'auto' &&
+    reference.themePreference === 'auto' &&
+    getResolvedTheme(current) !== undefined &&
+    getResolvedTheme(reference) !== undefined &&
+    getResolvedTheme(current) !== getResolvedTheme(reference)
+  );
+}
+
+function matchesThemePresetValue(
+  config: Record<string, unknown>,
+  theme: 'light' | 'dark',
+  field: keyof (typeof themePresets)['light']
+): boolean {
+  return deepEqual(config[field], themePresets[theme][field]);
+}
+
+function shouldIgnoreThemePresetBackedField(
+  current: Record<string, unknown>,
+  reference: Record<string, unknown>,
+  field: keyof (typeof themePresets)['light']
+): boolean {
+  if (!isPureResolvedThemeDrift(current, reference)) {
     return false;
   }
 
-  const aKeys = Object.keys(a);
-  const bKeys = Object.keys(b);
+  const currentTheme = getResolvedTheme(current);
+  const referenceTheme = getResolvedTheme(reference);
+  if (!currentTheme || !referenceTheme) {
+    return false;
+  }
 
-  if (aKeys.length !== bKeys.length) return false;
+  return (
+    matchesThemePresetValue(current, currentTheme, field) &&
+    matchesThemePresetValue(reference, referenceTheme, field)
+  );
+}
 
-  for (const key of aKeys) {
-    if (!deepEqual((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key])) {
-      return false;
+function formatThemePreference(
+  preference: unknown,
+  resolvedTheme: 'light' | 'dark' | undefined
+): string {
+  if (preference === 'auto') {
+    return resolvedTheme ? `Auto (resolved ${titleCase(resolvedTheme)})` : 'Auto';
+  }
+
+  if (preference === 'light' || preference === 'dark') {
+    return titleCase(preference);
+  }
+
+  return asString(preference);
+}
+
+function formatContrastReference(reference: unknown): string {
+  if (!reference || typeof reference !== 'object') {
+    return asString(reference);
+  }
+
+  const candidate = reference as ContrastReference;
+  const step = candidate.stepIndex * 10;
+  if (candidate.kind === 'palette') {
+    return `Palette ${(candidate.paletteIndex ?? 0) + 1}, step ${step}`;
+  }
+
+  return `Neutral, step ${step}`;
+}
+
+function formatContrastMode(value: unknown): string {
+  return value === 'manual' ? 'Manual' : 'Auto';
+}
+
+function formatTargetConstraint(constraint: Extract<Constraint, { type: 'target-color' }>): string {
+  const metricLabel = getTargetColorMetricLabel(
+    (constraint.metric ?? 'ok') as ColorDifferenceMetric
+  );
+  const parts = [constraint.targetHex.toUpperCase(), metricLabel];
+
+  if (constraint.mustPass) {
+    parts.push('Must pass');
+  }
+
+  if (!constraint.enabled) {
+    parts.push('Disabled');
+  }
+
+  return parts.join(' · ');
+}
+
+function formatRuleConstraint(constraint: Extract<Constraint, { type: 'contrast-rule' }>): string {
+  const scopeLabel = constraint.scope === 'neutral' ? 'Neutral' : 'All palettes';
+  const referenceLabel = constraint.reference === 'low' ? 'Low ref' : 'High ref';
+  const thresholdLabel = getConstraintThresholdLabel(constraint.level as ConstraintThresholdKey);
+  const parts = [
+    scopeLabel,
+    `Step ${constraint.stepIndex * 10}`,
+    referenceLabel,
+    `${constraint.algorithm as ContrastAlgorithm} ${thresholdLabel}`
+  ];
+
+  if (!constraint.enabled) {
+    parts.push('Disabled');
+  }
+
+  return parts.join(' · ');
+}
+
+function formatConstraint(constraint: Constraint): string {
+  return constraint.type === 'target-color'
+    ? formatTargetConstraint(constraint)
+    : formatRuleConstraint(constraint);
+}
+
+function formatConstraintLabel(constraint: Constraint): string {
+  return constraint.type === 'target-color' ? 'Target color' : 'Contrast rule';
+}
+
+function constraintContentEqual(left: Constraint, right: Constraint): boolean {
+  return deepEqual({ ...left, id: undefined }, { ...right, id: undefined });
+}
+
+function buildIndexedEntries(options: {
+  field: string;
+  labelForIndex: (index: number) => string;
+  currentValues: number[];
+  referenceValues: number[];
+  currentCount: number;
+  referenceCount: number;
+  defaultValue: number;
+}): DiffEntry[] {
+  const entries: DiffEntry[] = [];
+  const maxCount = Math.max(options.currentCount, options.referenceCount);
+
+  for (let index = 0; index < maxCount; index += 1) {
+    const currentPresent = index < options.currentCount;
+    const referencePresent = index < options.referenceCount;
+    const currentValue = currentPresent
+      ? (options.currentValues[index] ?? options.defaultValue)
+      : options.defaultValue;
+    const referenceValue = referencePresent
+      ? (options.referenceValues[index] ?? options.defaultValue)
+      : options.defaultValue;
+
+    if (currentPresent && referencePresent) {
+      if (currentValue !== referenceValue) {
+        entries.push(
+          createChangedEntry(
+            `${options.field}.${index}`,
+            options.labelForIndex(index),
+            currentValue,
+            referenceValue
+          )
+        );
+      }
+
+      continue;
+    }
+
+    if (!referencePresent && currentPresent && currentValue !== options.defaultValue) {
+      entries.push(
+        createOneSidedEntry(
+          'added',
+          `${options.field}.${index}`,
+          options.labelForIndex(index),
+          currentValue
+        )
+      );
+    }
+
+    if (!currentPresent && referencePresent && referenceValue !== options.defaultValue) {
+      entries.push(
+        createOneSidedEntry(
+          'removed',
+          `${options.field}.${index}`,
+          options.labelForIndex(index),
+          referenceValue
+        )
+      );
     }
   }
 
-  return true;
+  return entries;
 }
 
-/**
- * Compare two color state configurations and produce a structured diff.
- *
- * Focuses on design-relevant changes and excludes inspection-only settings.
- * Results are categorized as generation, contrast, or naming changes.
- *
- * @param current Current palette configuration
- * @param reference Reference palette configuration
- * @returns Structured diff suitable for presentation
- */
+function buildNamedEntries(options: {
+  field: string;
+  labelForIndex: (index: number) => string;
+  currentValues?: string[];
+  referenceValues?: string[];
+  currentCount: number;
+  referenceCount: number;
+}): DiffEntry[] {
+  const currentValues =
+    normalizeCustomPaletteNames(options.currentValues, options.currentCount) ?? [];
+  const referenceValues =
+    normalizeCustomPaletteNames(options.referenceValues, options.referenceCount) ?? [];
+  const entries: DiffEntry[] = [];
+  const maxCount = Math.max(options.currentCount, options.referenceCount);
+
+  for (let index = 0; index < maxCount; index += 1) {
+    const currentPresent = index < options.currentCount;
+    const referencePresent = index < options.referenceCount;
+    const currentValue = normalizeCustomPaletteName(currentValues[index]) ?? '';
+    const referenceValue = normalizeCustomPaletteName(referenceValues[index]) ?? '';
+
+    if (currentPresent && referencePresent) {
+      if (currentValue && referenceValue && currentValue !== referenceValue) {
+        entries.push(
+          createChangedEntry(
+            `${options.field}.${index}`,
+            options.labelForIndex(index),
+            currentValue,
+            referenceValue
+          )
+        );
+      } else if (!referenceValue && currentValue) {
+        entries.push(
+          createOneSidedEntry(
+            'added',
+            `${options.field}.${index}`,
+            options.labelForIndex(index),
+            currentValue
+          )
+        );
+      } else if (referenceValue && !currentValue) {
+        entries.push(
+          createOneSidedEntry(
+            'removed',
+            `${options.field}.${index}`,
+            options.labelForIndex(index),
+            referenceValue
+          )
+        );
+      }
+
+      continue;
+    }
+
+    if (!referencePresent && currentPresent && currentValue) {
+      entries.push(
+        createOneSidedEntry(
+          'added',
+          `${options.field}.${index}`,
+          options.labelForIndex(index),
+          currentValue
+        )
+      );
+    }
+
+    if (!currentPresent && referencePresent && referenceValue) {
+      entries.push(
+        createOneSidedEntry(
+          'removed',
+          `${options.field}.${index}`,
+          options.labelForIndex(index),
+          referenceValue
+        )
+      );
+    }
+  }
+
+  return entries;
+}
+
 export function diffColorStates(
   current: Record<string, unknown>,
   reference: Record<string, unknown>
 ): ConfigurationDiff {
   const generationChanges: DiffEntry[] = [];
   const contrastChanges: DiffEntry[] = [];
+  const constraintChanges: DiffEntry[] = [];
   const namingChanges: DiffEntry[] = [];
 
-  // Check generation settings
-  for (const field of GENERATION_FIELDS) {
-    const currentValue = current[field];
-    const referenceValue = reference[field];
+  for (const field of [
+    'numColors',
+    'numPalettes',
+    'baseColor',
+    'warmth',
+    'warmthHue',
+    'x1',
+    'y1',
+    'x2',
+    'y2',
+    'chromaMultiplier'
+  ]) {
+    if (!deepEqual(current[field], reference[field])) {
+      if (
+        THEME_PRESET_BACKED_GENERATION_FIELDS.has(field) &&
+        shouldIgnoreThemePresetBackedField(
+          current,
+          reference,
+          field as keyof (typeof themePresets)['light']
+        )
+      ) {
+        continue;
+      }
 
-    if (!deepEqual(currentValue, referenceValue)) {
-      generationChanges.push({
-        field,
-        label: FIELD_LABELS[field] ?? field,
-        currentValue,
-        referenceValue
-      });
+      generationChanges.push(
+        createChangedEntry(
+          field,
+          GENERATION_FIELD_LABELS[field] ?? field,
+          current[field],
+          reference[field]
+        )
+      );
     }
   }
 
-  // Check contrast settings
-  for (const field of CONTRAST_FIELDS) {
-    const currentValue = current[field];
-    const referenceValue = reference[field];
+  if (current.themePreference !== reference.themePreference) {
+    generationChanges.push({
+      field: 'themePreference',
+      label: GENERATION_FIELD_LABELS.themePreference,
+      kind: 'changed',
+      referenceValue: formatThemePreference(reference.themePreference, getResolvedTheme(reference)),
+      currentValue: formatThemePreference(current.themePreference, getResolvedTheme(current))
+    });
+  }
 
-    if (!deepEqual(currentValue, referenceValue)) {
+  generationChanges.push(
+    ...buildIndexedEntries({
+      field: 'lightnessNudgers',
+      labelForIndex: (index) => `Neutral step ${index * 10} lightness adjustment`,
+      currentValues: asNumberArray(current.lightnessNudgers),
+      referenceValues: asNumberArray(reference.lightnessNudgers),
+      currentCount: asNumber(current.numColors, DEFAULT_NUM_COLORS),
+      referenceCount: asNumber(reference.numColors, DEFAULT_NUM_COLORS),
+      defaultValue: 0
+    }),
+    ...buildIndexedEntries({
+      field: 'hueNudgers',
+      labelForIndex: (index) => `Palette ${index + 1} hue adjustment`,
+      currentValues: asNumberArray(current.hueNudgers),
+      referenceValues: asNumberArray(reference.hueNudgers),
+      currentCount: asNumber(current.numPalettes, DEFAULT_NUM_PALETTES),
+      referenceCount: asNumber(reference.numPalettes, DEFAULT_NUM_PALETTES),
+      defaultValue: 0
+    }),
+    ...buildIndexedEntries({
+      field: 'stepSaturationNudgers',
+      labelForIndex: (index) => `Step ${index * 10} saturation adjustment`,
+      currentValues: asNumberArray(current.stepSaturationNudgers),
+      referenceValues: asNumberArray(reference.stepSaturationNudgers),
+      currentCount: asNumber(current.numColors, DEFAULT_NUM_COLORS),
+      referenceCount: asNumber(reference.numColors, DEFAULT_NUM_COLORS),
+      defaultValue: 0
+    }),
+    ...buildIndexedEntries({
+      field: 'paletteSaturationNudgers',
+      labelForIndex: (index) => `Palette ${index + 1} saturation adjustment`,
+      currentValues: asNumberArray(current.paletteSaturationNudgers),
+      referenceValues: asNumberArray(reference.paletteSaturationNudgers),
+      currentCount: asNumber(current.numPalettes, DEFAULT_NUM_PALETTES),
+      referenceCount: asNumber(reference.numPalettes, DEFAULT_NUM_PALETTES),
+      defaultValue: 0
+    }),
+    ...buildIndexedEntries({
+      field: 'paletteChromaNudgers',
+      labelForIndex: (index) => `Palette ${index + 1} chroma adjustment`,
+      currentValues: asNumberArray(current.paletteChromaNudgers),
+      referenceValues: asNumberArray(reference.paletteChromaNudgers),
+      currentCount: asNumber(current.numPalettes, DEFAULT_NUM_PALETTES),
+      referenceCount: asNumber(reference.numPalettes, DEFAULT_NUM_PALETTES),
+      defaultValue: 1
+    })
+  );
+
+  if (current.contrastMode !== reference.contrastMode) {
+    contrastChanges.push({
+      field: 'contrastMode',
+      label: 'Contrast mode',
+      kind: 'changed',
+      referenceValue: formatContrastMode(reference.contrastMode),
+      currentValue: formatContrastMode(current.contrastMode)
+    });
+  }
+
+  const currentAuto = current.contrastMode === 'auto';
+  const referenceAuto = reference.contrastMode === 'auto';
+  const currentManual = current.contrastMode === 'manual';
+  const referenceManual = reference.contrastMode === 'manual';
+
+  if (currentAuto && referenceAuto) {
+    if (
+      !deepEqual(current.lowReference, reference.lowReference) &&
+      !shouldIgnoreThemePresetBackedField(current, reference, 'lowReference')
+    ) {
       contrastChanges.push({
-        field,
-        label: FIELD_LABELS[field] ?? field,
-        currentValue,
-        referenceValue
+        field: 'lowReference',
+        label: 'Low contrast reference',
+        kind: 'changed',
+        referenceValue: formatContrastReference(reference.lowReference),
+        currentValue: formatContrastReference(current.lowReference)
+      });
+    }
+
+    if (
+      !deepEqual(current.highReference, reference.highReference) &&
+      !shouldIgnoreThemePresetBackedField(current, reference, 'highReference')
+    ) {
+      contrastChanges.push({
+        field: 'highReference',
+        label: 'High contrast reference',
+        kind: 'changed',
+        referenceValue: formatContrastReference(reference.highReference),
+        currentValue: formatContrastReference(current.highReference)
       });
     }
   }
 
-  // Check naming settings
-  for (const field of NAMING_FIELDS) {
-    const currentValue = current[field];
-    const referenceValue = reference[field];
+  if (currentManual || referenceManual) {
+    const currentContrast = (current.contrast as Record<string, unknown> | undefined) ?? {};
+    const referenceContrast = (reference.contrast as Record<string, unknown> | undefined) ?? {};
 
-    if (!deepEqual(currentValue, referenceValue)) {
-      namingChanges.push({
-        field,
-        label: FIELD_LABELS[field] ?? field,
-        currentValue,
-        referenceValue
+    if (currentContrast.low !== referenceContrast.low) {
+      contrastChanges.push({
+        field: 'contrast.low',
+        label: 'Low contrast color',
+        kind: 'changed',
+        referenceValue: asString(referenceContrast.low),
+        currentValue: asString(currentContrast.low)
+      });
+    }
+
+    if (currentContrast.high !== referenceContrast.high) {
+      contrastChanges.push({
+        field: 'contrast.high',
+        label: 'High contrast color',
+        kind: 'changed',
+        referenceValue: asString(referenceContrast.high),
+        currentValue: asString(currentContrast.high)
       });
     }
   }
+
+  if (!deepEqual(current.solveAdjacentStopLows, reference.solveAdjacentStopLows)) {
+    contrastChanges.push(
+      createChangedEntry(
+        'solveAdjacentStopLows',
+        'Solve adjacent stops',
+        current.solveAdjacentStopLows,
+        reference.solveAdjacentStopLows
+      )
+    );
+  }
+
+  const currentConstraints = asConstraints(current.constraints);
+  const referenceConstraints = asConstraints(reference.constraints);
+  const referenceConstraintMap = new Map(
+    referenceConstraints.map((constraint) => [constraint.id, constraint])
+  );
+  const currentConstraintMap = new Map(
+    currentConstraints.map((constraint) => [constraint.id, constraint])
+  );
+  const referenceConstraintIndexById = new Map(
+    referenceConstraints.map((constraint, index) => [constraint.id, index])
+  );
+  let referenceCursor = 0;
+
+  for (const constraint of currentConstraints) {
+    const referenceConstraint = referenceConstraintMap.get(constraint.id);
+
+    if (!referenceConstraint) {
+      constraintChanges.push({
+        field: `constraint.${constraint.id}`,
+        label: formatConstraintLabel(constraint),
+        kind: 'added',
+        currentValue: formatConstraint(constraint)
+      });
+      continue;
+    }
+
+    const targetReferenceIndex = referenceConstraintIndexById.get(constraint.id) ?? referenceCursor;
+    while (referenceCursor < targetReferenceIndex) {
+      const missingReferenceConstraint = referenceConstraints[referenceCursor];
+      if (!currentConstraintMap.has(missingReferenceConstraint.id)) {
+        constraintChanges.push({
+          field: `constraint.${missingReferenceConstraint.id}`,
+          label: formatConstraintLabel(missingReferenceConstraint),
+          kind: 'removed',
+          referenceValue: formatConstraint(missingReferenceConstraint)
+        });
+      }
+      referenceCursor += 1;
+    }
+
+    if (!constraintContentEqual(constraint, referenceConstraint)) {
+      constraintChanges.push({
+        field: `constraint.${constraint.id}`,
+        label: formatConstraintLabel(constraint),
+        kind: 'changed',
+        referenceValue: formatConstraint(referenceConstraint),
+        currentValue: formatConstraint(constraint)
+      });
+    }
+
+    referenceCursor = targetReferenceIndex + 1;
+  }
+
+  while (referenceCursor < referenceConstraints.length) {
+    const missingReferenceConstraint = referenceConstraints[referenceCursor];
+    if (!currentConstraintMap.has(missingReferenceConstraint.id)) {
+      constraintChanges.push({
+        field: `constraint.${missingReferenceConstraint.id}`,
+        label: formatConstraintLabel(missingReferenceConstraint),
+        kind: 'removed',
+        referenceValue: formatConstraint(missingReferenceConstraint)
+      });
+    }
+    referenceCursor += 1;
+  }
+
+  const currentNeutralName = normalizeCustomPaletteName(current.customNeutralName);
+  const referenceNeutralName = normalizeCustomPaletteName(reference.customNeutralName);
+
+  if (currentNeutralName && referenceNeutralName && currentNeutralName !== referenceNeutralName) {
+    namingChanges.push({
+      field: 'customNeutralName',
+      label: 'Neutral palette name',
+      kind: 'changed',
+      referenceValue: referenceNeutralName,
+      currentValue: currentNeutralName
+    });
+  } else if (currentNeutralName && !referenceNeutralName) {
+    namingChanges.push({
+      field: 'customNeutralName',
+      label: 'Neutral palette name',
+      kind: 'added',
+      currentValue: currentNeutralName
+    });
+  } else if (!currentNeutralName && referenceNeutralName) {
+    namingChanges.push({
+      field: 'customNeutralName',
+      label: 'Neutral palette name',
+      kind: 'removed',
+      referenceValue: referenceNeutralName
+    });
+  }
+
+  namingChanges.push(
+    ...buildNamedEntries({
+      field: 'customPaletteNames',
+      labelForIndex: (index) => `Palette ${index + 1} name`,
+      currentValues: current.customPaletteNames as string[] | undefined,
+      referenceValues: reference.customPaletteNames as string[] | undefined,
+      currentCount: asNumber(current.numPalettes, DEFAULT_NUM_PALETTES),
+      referenceCount: asNumber(reference.numPalettes, DEFAULT_NUM_PALETTES)
+    })
+  );
 
   const hasChanges =
-    generationChanges.length > 0 || contrastChanges.length > 0 || namingChanges.length > 0;
+    generationChanges.length > 0 ||
+    contrastChanges.length > 0 ||
+    constraintChanges.length > 0 ||
+    namingChanges.length > 0;
 
   return {
     hasChanges,
     generationChanges,
     contrastChanges,
+    constraintChanges,
     namingChanges,
     timestamp: Date.now()
   };

--- a/src/lib/comparisonViewAnnotations.spec.ts
+++ b/src/lib/comparisonViewAnnotations.spec.ts
@@ -39,6 +39,25 @@ describe('comparisonViewAnnotations', () => {
     ).toBe('Changed');
   });
 
+  it('emits a Changed chip when the color difference equals the threshold', () => {
+    const currentColor = new Color('oklch', [0.7, 0.12, 210]);
+    const referenceColor = new Color('oklch', [0.7, 0.1, 210]);
+    const threshold = currentColor.deltaEOK(referenceColor);
+
+    expect(
+      buildComparisonAnnotation({
+        currentHex: '#58b6d8',
+        referenceHex: '#5cb2cd',
+        currentColor,
+        referenceColor,
+        metric: 'ok',
+        threshold,
+        currentStatusConfig: baseConfig,
+        referenceStatusConfig: baseConfig
+      }).chip?.label
+    ).toBe('Changed');
+  });
+
   it('detects wide-gamut color-only differences even when sRGB hex matches', () => {
     expect(
       buildComparisonAnnotation({

--- a/src/lib/comparisonViewAnnotations.ts
+++ b/src/lib/comparisonViewAnnotations.ts
@@ -233,7 +233,7 @@ export function buildComparisonAnnotation(params: {
     referenceStatusConfig.gamutSpace,
     metric
   );
-  if (colorDifference > threshold) {
+  if (colorDifference >= threshold) {
     return {
       chip: {
         label: 'Changed',

--- a/src/lib/components/ComparisonControls.svelte
+++ b/src/lib/components/ComparisonControls.svelte
@@ -5,8 +5,15 @@
     setComparisonMetric,
     setSwatchChangeThreshold
   } from '$lib/stores';
+  import type { ColorDifferenceMetric } from '$lib/types';
   import SelectField from './SelectField.svelte';
   import SliderNumberField from './SliderNumberField.svelte';
+
+  interface Props {
+    onHistoryCommit?: (message: string) => void;
+  }
+
+  let { onHistoryCommit = () => {} }: Props = $props();
 
   // Comparison metric options
   const metricOptions = [
@@ -14,12 +21,22 @@
     { value: '2000', label: 'Delta E 2000' }
   ];
 
+  const thresholdFieldByMetric: Record<
+    ColorDifferenceMetric,
+    { min: number; max: number; step: number }
+  > = {
+    ok: { min: 0, max: 0.1, step: 0.005 },
+    '2000': { min: 0, max: 10, step: 0.5 }
+  };
+
   let comparisonMetricLocal = $derived($comparisonMetric);
   let swatchChangeThresholdLocal = $derived($swatchChangeThreshold);
+  let thresholdFieldLocal = $derived(thresholdFieldByMetric[comparisonMetricLocal]);
 
   function handleMetricChange(value: string): void {
     if (value === 'ok' || value === '2000') {
       setComparisonMetric(value);
+      onHistoryCommit('Comparison metric changed');
     }
   }
 
@@ -28,6 +45,7 @@
       const value = event.currentTarget.valueAsNumber;
       if (!Number.isNaN(value)) {
         setSwatchChangeThreshold(value);
+        onHistoryCommit('Swatch change threshold changed');
       }
     }
   }
@@ -50,10 +68,11 @@
     id="swatch-threshold"
     label="Swatch Change Threshold"
     valueInputLabel="Swatch change threshold value"
+    rangeAriaLabel="Swatch change threshold slider"
     bind:value={swatchChangeThresholdLocal}
-    min={0}
-    max={100}
-    step={1}
+    min={thresholdFieldLocal.min}
+    max={thresholdFieldLocal.max}
+    step={thresholdFieldLocal.step}
     groupHelpText="Minimum color difference before a swatch is flagged as changed. Higher values suppress smaller changes."
     onRangeChange={handleThresholdChange}
     onNumberChange={handleThresholdChange}

--- a/src/lib/components/ConfigurationDiffDisplay.dom.spec.ts
+++ b/src/lib/components/ConfigurationDiffDisplay.dom.spec.ts
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+
+import ConfigurationDiffDisplay from './ConfigurationDiffDisplay.svelte';
+
+function createConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    numColors: 11,
+    numPalettes: 11,
+    baseColor: '#5EF784',
+    warmth: -7,
+    warmthHue: 142,
+    x1: 0.16,
+    y1: 0,
+    x2: 0.28,
+    y2: 0.38,
+    chromaMultiplier: 1,
+    lightnessNudgers: Array.from({ length: 11 }, () => 0),
+    hueNudgers: Array.from({ length: 11 }, () => 0),
+    stepSaturationNudgers: Array.from({ length: 11 }, () => 0),
+    paletteSaturationNudgers: Array.from({ length: 11 }, () => 0),
+    paletteChromaNudgers: Array.from({ length: 11 }, () => 1),
+    contrastMode: 'auto',
+    lowStep: 0,
+    highStep: 10,
+    lowReference: { kind: 'neutral', stepIndex: 0 },
+    highReference: { kind: 'neutral', stepIndex: 10 },
+    contrast: { low: '#ffffff', high: '#000000' },
+    solveAdjacentStopLows: true,
+    themePreference: 'light',
+    currentTheme: 'light',
+    customNeutralName: undefined,
+    customPaletteNames: undefined,
+    constraints: [],
+    ...overrides
+  };
+}
+
+describe('ConfigurationDiffDisplay', () => {
+  it('renders changed entries in Reference to Current order', () => {
+    render(ConfigurationDiffDisplay, {
+      props: {
+        currentConfig: createConfig({ baseColor: '#00FF00' }),
+        referenceConfig: createConfig()
+      }
+    });
+
+    const card = screen.getByTestId('configuration-diff-card');
+    const referenceValue = screen.getByText('#5EF784');
+    const currentValue = screen.getByText('#00FF00');
+
+    expect(card).toBeInTheDocument();
+    expect(screen.getByText('Generation Settings')).toBeInTheDocument();
+    expect(screen.getByText('Base color')).toBeInTheDocument();
+    expect(
+      referenceValue.compareDocumentPosition(currentValue) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('keeps an explicit success state when there are no configuration changes', () => {
+    render(ConfigurationDiffDisplay, {
+      props: {
+        currentConfig: createConfig(),
+        referenceConfig: createConfig()
+      }
+    });
+
+    expect(screen.getByTestId('configuration-diff-card')).toBeInTheDocument();
+    expect(screen.getByText('No configuration changes')).toBeInTheDocument();
+  });
+});

--- a/src/lib/components/ConfigurationDiffDisplay.svelte
+++ b/src/lib/components/ConfigurationDiffDisplay.svelte
@@ -1,116 +1,127 @@
 <script lang="ts">
-  import { referenceConfiguration } from '$lib/stores';
-  import { diffColorStates } from '$lib/comparisonDiff';
+  import { diffColorStates, type DiffEntry } from '$lib/comparisonDiff';
+  import Badge from './Badge.svelte';
   import Card from './Card.svelte';
   import Icon from './Icon.svelte';
 
   interface Props {
     currentConfig: Record<string, unknown>;
+    referenceConfig: Record<string, unknown> | null;
   }
 
-  let { currentConfig }: Props = $props();
+  interface DiffSection {
+    key: string;
+    title: string;
+    icon: 'settings' | 'contrast' | 'check' | 'edit';
+    entries: DiffEntry[];
+  }
 
-  let configDiff = $derived.by(() => {
-    if (!$referenceConfiguration) return null;
-    return diffColorStates(
-      currentConfig,
-      $referenceConfiguration as unknown as Record<string, unknown>
-    );
+  let { currentConfig, referenceConfig }: Props = $props();
+
+  let configDiff = $derived.by(() =>
+    referenceConfig ? diffColorStates(currentConfig, referenceConfig) : null
+  );
+
+  let sections = $derived.by<DiffSection[]>(() => {
+    if (!configDiff) {
+      return [];
+    }
+
+    const nextSections: DiffSection[] = [
+      {
+        key: 'generation',
+        title: 'Generation Settings',
+        icon: 'settings',
+        entries: configDiff.generationChanges
+      },
+      {
+        key: 'contrast',
+        title: 'Contrast Settings',
+        icon: 'contrast',
+        entries: configDiff.contrastChanges
+      },
+      {
+        key: 'constraints',
+        title: 'Constraints',
+        icon: 'check',
+        entries: configDiff.constraintChanges
+      },
+      {
+        key: 'naming',
+        title: 'Custom Names',
+        icon: 'edit',
+        entries: configDiff.namingChanges
+      }
+    ];
+
+    return nextSections.filter((section) => section.entries.length > 0);
   });
 
-  function formatValue(value: unknown): string {
-    if (Array.isArray(value)) {
-      return `[${value.length} items]`;
-    }
-    if (typeof value === 'object' && value !== null) {
-      return '[object]';
-    }
-    return String(value);
+  function getActionLabel(kind: DiffEntry['kind']): 'Added' | 'Removed' {
+    return kind === 'added' ? 'Added' : 'Removed';
+  }
+
+  function getActionVariant(kind: DiffEntry['kind']): 'accent' | 'warning' {
+    return kind === 'added' ? 'accent' : 'warning';
+  }
+
+  function getOneSidedValue(entry: DiffEntry): string {
+    return entry.kind === 'added' ? (entry.currentValue ?? '') : (entry.referenceValue ?? '');
   }
 </script>
 
-{#if configDiff && configDiff.hasChanges}
+{#if configDiff}
   <Card
     title="Configuration Diff"
-    subtitle="Differences from Reference"
+    subtitle="Authored palette-configuration changes from the pinned reference"
     data-testid="configuration-diff-card"
   >
-    <div class="diff-content">
-      {#if configDiff.generationChanges.length > 0}
-        <div class="diff-section">
-          <h4 class="section-title">
-            <Icon name="settings" size="sm" />
-            Generation Settings
-          </h4>
-          <ul class="diff-list">
-            {#each configDiff.generationChanges as change (change.field)}
-              <li class="diff-entry">
-                <span class="field-label">{change.label}</span>
-                <span class="field-values">
-                  <span class="current-value">{formatValue(change.currentValue)}</span>
-                  <span class="arrow">→</span>
-                  <span class="reference-value">{formatValue(change.referenceValue)}</span>
-                </span>
-              </li>
-            {/each}
-          </ul>
-        </div>
-      {/if}
+    {#if configDiff.hasChanges}
+      <div class="diff-content">
+        {#each sections as section (section.key)}
+          <section class="diff-section" aria-label={section.title}>
+            <h3 class="section-title">
+              <Icon name={section.icon} size="sm" />
+              <span>{section.title}</span>
+            </h3>
 
-      {#if configDiff.contrastChanges.length > 0}
-        <div class="diff-section">
-          <h4 class="section-title">
-            <Icon name="contrast" size="sm" />
-            Contrast Settings
-          </h4>
-          <ul class="diff-list">
-            {#each configDiff.contrastChanges as change (change.field)}
-              <li class="diff-entry">
-                <span class="field-label">{change.label}</span>
-                <span class="field-values">
-                  <span class="current-value">{formatValue(change.currentValue)}</span>
-                  <span class="arrow">→</span>
-                  <span class="reference-value">{formatValue(change.referenceValue)}</span>
-                </span>
-              </li>
-            {/each}
-          </ul>
-        </div>
-      {/if}
+            <ul class="diff-list">
+              {#each section.entries as entry (entry.field)}
+                <li class="diff-entry">
+                  <div class="entry-copy">
+                    <span class="field-label">{entry.label}</span>
 
-      {#if configDiff.namingChanges.length > 0}
-        <div class="diff-section">
-          <h4 class="section-title">
-            <Icon name="edit" size="sm" />
-            Custom Names
-          </h4>
-          <ul class="diff-list">
-            {#each configDiff.namingChanges as change (change.field)}
-              <li class="diff-entry">
-                <span class="field-label">{change.label}</span>
-                <span class="field-values">
-                  <span class="current-value">{formatValue(change.currentValue)}</span>
-                  <span class="arrow">→</span>
-                  <span class="reference-value">{formatValue(change.referenceValue)}</span>
-                </span>
-              </li>
-            {/each}
-          </ul>
-        </div>
-      {/if}
-    </div>
+                    {#if entry.kind === 'changed'}
+                      <div class="value-flow" aria-label={`${entry.label} reference to current`}>
+                        <span class="value-chip value-chip--reference">{entry.referenceValue}</span>
+                        <span class="value-arrow" aria-hidden="true">→</span>
+                        <span class="value-chip value-chip--current">{entry.currentValue}</span>
+                      </div>
+                    {:else}
+                      <div class="value-stack">
+                        <Badge variant={getActionVariant(entry.kind)}
+                          >{getActionLabel(entry.kind)}</Badge
+                        >
+                        <span class="value-chip value-chip--single">{getOneSidedValue(entry)}</span>
+                      </div>
+                    {/if}
+                  </div>
+                </li>
+              {/each}
+            </ul>
+          </section>
+        {/each}
+      </div>
+    {:else}
+      <p class="success-state" role="status">No configuration changes</p>
+    {/if}
   </Card>
-{:else if configDiff}
-  <div class="no-changes-notice" role="status">
-    <Icon name="check" size="sm" />
-    <p>Current and Reference configurations match</p>
-  </div>
 {/if}
 
 <style>
   .diff-content {
     display: grid;
-    gap: var(--space-md);
+    gap: var(--space-lg);
   }
 
   .diff-section {
@@ -122,83 +133,89 @@
     display: flex;
     align-items: center;
     gap: var(--space-xs);
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: var(--text-secondary);
     margin: 0;
-    padding: 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: var(--letter-spacing-wide);
     text-transform: uppercase;
-    letter-spacing: 0.5px;
   }
 
   .diff-list {
     display: grid;
-    gap: var(--space-xs);
+    gap: var(--space-sm);
     margin: 0;
     padding: 0;
     list-style: none;
   }
 
   .diff-entry {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+    padding: var(--space-sm);
+    border: var(--border-width-thin) solid color-mix(in oklab, var(--border) 72%, transparent);
+    border-radius: var(--radius-sm);
+    background: color-mix(in oklab, var(--bg-primary) 60%, var(--bg-secondary));
+  }
+
+  .entry-copy {
+    display: grid;
     gap: var(--space-sm);
-    padding: var(--space-xs) var(--space-sm);
-    background: var(--bg-secondary);
-    border-radius: 4px;
-    font-size: 0.875rem;
   }
 
   .field-label {
-    font-weight: 500;
     color: var(--text-primary);
-    flex-shrink: 0;
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
   }
 
-  .field-values {
-    display: flex;
-    align-items: center;
-    gap: var(--space-xs);
-    font-family: monospace;
-    font-size: 0.8125rem;
-    color: var(--text-secondary);
-    overflow: auto;
-    flex-shrink: 1;
-    min-width: 0;
-  }
-
-  .current-value {
-    padding: 2px 6px;
-    background: var(--bg-tertiary);
-    border-radius: 3px;
-    color: var(--text-primary);
-  }
-
-  .arrow {
-    flex-shrink: 0;
-    color: var(--text-secondary);
-  }
-
-  .reference-value {
-    padding: 2px 6px;
-    background: var(--bg-tertiary);
-    border-radius: 3px;
-    color: var(--text-primary);
-  }
-
-  .no-changes-notice {
+  .value-flow,
+  .value-stack {
     display: flex;
     align-items: center;
     gap: var(--space-sm);
-    padding: var(--space-md);
-    background: var(--bg-secondary);
-    border-radius: 6px;
-    color: var(--text-secondary);
-    font-size: 0.875rem;
+    flex-wrap: wrap;
   }
 
-  .no-changes-notice p {
+  .value-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: var(--touch-target-min);
+    padding: var(--space-xs) var(--space-sm);
+    border-radius: var(--radius-xs);
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    font-family:
+      ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+      'Courier New', monospace;
+    font-size: var(--font-size-xs);
+    line-height: var(--line-height-tight);
+    overflow-wrap: anywhere;
+  }
+
+  .value-chip--reference {
+    border: var(--border-width-thin) solid color-mix(in oklab, var(--border) 88%, transparent);
+  }
+
+  .value-chip--current {
+    border: var(--border-width-thin) solid color-mix(in oklab, var(--accent) 38%, var(--border));
+    background: color-mix(in oklab, var(--accent) 8%, var(--bg-primary));
+  }
+
+  .value-chip--single {
+    border: var(--border-width-thin) solid color-mix(in oklab, var(--border) 88%, transparent);
+  }
+
+  .value-arrow {
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .success-state {
     margin: 0;
+    padding: var(--space-sm) var(--space-md);
+    border: var(--border-width-thin) solid color-mix(in oklab, var(--border) 72%, transparent);
+    border-radius: var(--radius-sm);
+    background: color-mix(in oklab, var(--bg-primary) 72%, var(--bg-secondary));
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
   }
 </style>

--- a/src/lib/components/ExportPreviewDialog.svelte
+++ b/src/lib/components/ExportPreviewDialog.svelte
@@ -6,6 +6,7 @@
     closeExportPreview,
     exportPreviewDialog,
     type ExportFormat,
+    type ExportPreviewData,
     type ExportScope
   } from '$lib/help/exportPreviewStore';
   import {
@@ -67,10 +68,22 @@
   let opener = $derived($exportPreviewDialog.opener);
   let scope = $derived<ExportScope>($exportPreviewDialog.scope);
   let initialFormat = $derived($exportPreviewDialog.initialFormat);
+  let dataOverride = $derived<ExportPreviewData | null>($exportPreviewDialog.dataOverride);
 
-  const scoped = $derived(scopeData(scope));
+  const exportSource = $derived(
+    dataOverride ?? {
+      neutrals,
+      palettes,
+      lowContrastColor,
+      displayNeutrals,
+      displayPalettes,
+      customNeutralName,
+      customPaletteNames
+    }
+  );
+  const scoped = $derived(scopeData(scope, exportSource));
   const exportNameOptions = $derived<ExportNameOptions>({
-    lowContrastColor,
+    lowContrastColor: exportSource.lowContrastColor ?? lowContrastColor,
     customNeutralName: scoped.customNeutralName,
     customPaletteNames: scoped.customPaletteNames
   });
@@ -216,7 +229,10 @@
     tabs[index]?.focus({ preventScroll: true });
   }
 
-  function scopeData(s: ExportScope): {
+  function scopeData(
+    s: ExportScope,
+    source: ExportPreviewData
+  ): {
     neutrals: string[];
     palettes: string[][];
     displayNeutrals: string[];
@@ -226,26 +242,26 @@
   } {
     if (s === 'all') {
       return {
-        neutrals,
-        palettes,
-        displayNeutrals,
-        displayPalettes,
-        customNeutralName,
-        customPaletteNames
+        neutrals: source.neutrals,
+        palettes: source.palettes,
+        displayNeutrals: source.displayNeutrals ?? source.neutrals,
+        displayPalettes: source.displayPalettes ?? source.palettes,
+        customNeutralName: source.customNeutralName,
+        customPaletteNames: source.customPaletteNames
       };
     }
     if (s === 'neutral') {
       return {
-        neutrals,
+        neutrals: source.neutrals,
         palettes: [],
-        displayNeutrals,
+        displayNeutrals: source.displayNeutrals ?? source.neutrals,
         displayPalettes: [],
-        customNeutralName,
+        customNeutralName: source.customNeutralName,
         customPaletteNames: undefined
       };
     }
     const i = s.paletteIndex;
-    if (i < 0 || i >= palettes.length) {
+    if (i < 0 || i >= source.palettes.length) {
       return {
         neutrals: [],
         palettes: [],
@@ -257,11 +273,13 @@
     }
     return {
       neutrals: [],
-      palettes: [palettes[i]],
+      palettes: [source.palettes[i]],
       displayNeutrals: [],
-      displayPalettes: displayPalettes[i] ? [displayPalettes[i]] : [],
+      displayPalettes: source.displayPalettes?.[i] ? [source.displayPalettes[i]] : [],
       customNeutralName: undefined,
-      customPaletteNames: customPaletteNames?.[i] ? [customPaletteNames[i]] : undefined
+      customPaletteNames: source.customPaletteNames?.[i]
+        ? [source.customPaletteNames[i]]
+        : undefined
     };
   }
 

--- a/src/lib/components/NeutralPalette.svelte
+++ b/src/lib/components/NeutralPalette.svelte
@@ -31,6 +31,9 @@
     readonly?: boolean;
     contrastColorsOverride?: { low: string; high: string };
     contrastAlgorithmOverride?: ContrastAlgorithm;
+    customNeutralNameOverride?: string;
+    exportNeutralsHex?: string[];
+    exportNeutralsDisplay?: string[];
   }
 
   let {
@@ -45,10 +48,14 @@
     onHistoryCommit,
     readonly = false,
     contrastColorsOverride = undefined,
-    contrastAlgorithmOverride = undefined
+    contrastAlgorithmOverride = undefined,
+    customNeutralNameOverride = undefined,
+    exportNeutralsHex = undefined,
+    exportNeutralsDisplay = undefined
   }: Props = $props();
 
   const effectiveContrastLow = $derived(contrastColorsOverride?.low ?? $contrastColors.low);
+  const activeCustomNeutralName = $derived(customNeutralNameOverride ?? $customNeutralName);
 
   const nonNullNeutralsHex = $derived(neutralsHex.filter((h): h is string => h !== null));
 
@@ -59,7 +66,7 @@
   );
   const neutralName = $derived(
     nonNullNeutralsHex.length > 0
-      ? resolveNeutralPaletteName(nonNullNeutralsHex, effectiveContrastLow, $customNeutralName)
+      ? resolveNeutralPaletteName(nonNullNeutralsHex, effectiveContrastLow, activeCustomNeutralName)
       : 'Gray'
   );
 
@@ -102,6 +109,18 @@
 
   function handleCopyClick(event: MouseEvent): void {
     const opener = event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+    if (exportNeutralsHex) {
+      openExportPreview('neutral', 'list', opener, {
+        neutrals: exportNeutralsHex,
+        palettes: [],
+        lowContrastColor: effectiveContrastLow,
+        displayNeutrals: exportNeutralsDisplay ?? exportNeutralsHex,
+        displayPalettes: [],
+        customNeutralName: customNeutralNameOverride
+      });
+      return;
+    }
+
     openExportPreview('neutral', 'list', opener);
   }
 
@@ -127,14 +146,18 @@
   {#if neutralsHex.length > 0}
     <div class="neutral-header">
       <h3 class="neutral-name-heading">
-        <PaletteNameEditor
-          value={$customNeutralName}
-          fallbackValue={generatedNeutralName}
-          editButtonAriaLabel="Edit name for neutral palette"
-          inputAriaLabel="Neutral palette name"
-          data-testid="neutral-palette-name"
-          onCommit={handleNeutralNameCommit}
-        />
+        {#if readonly}
+          <span data-testid="neutral-palette-name">{neutralName}</span>
+        {:else}
+          <PaletteNameEditor
+            value={$customNeutralName}
+            fallbackValue={generatedNeutralName}
+            editButtonAriaLabel="Edit name for neutral palette"
+            inputAriaLabel="Neutral palette name"
+            data-testid="neutral-palette-name"
+            onCommit={handleNeutralNameCommit}
+          />
+        {/if}
       </h3>
       <Button
         ariaLabel={`Copy ${neutralName} palette`}

--- a/src/lib/components/PaletteGrid.svelte
+++ b/src/lib/components/PaletteGrid.svelte
@@ -34,6 +34,9 @@
     readonly?: boolean;
     contrastColorsOverride?: { low: string; high: string };
     contrastAlgorithmOverride?: ContrastAlgorithm;
+    customPaletteNamesOverride?: string[];
+    exportPalettesHex?: string[][];
+    exportPalettesDisplay?: string[][];
   }
 
   let {
@@ -50,10 +53,14 @@
     onHistoryCommit,
     readonly = false,
     contrastColorsOverride = undefined,
-    contrastAlgorithmOverride = undefined
+    contrastAlgorithmOverride = undefined,
+    customPaletteNamesOverride = undefined,
+    exportPalettesHex = undefined,
+    exportPalettesDisplay = undefined
   }: Props = $props();
 
   const effectiveContrastLow = $derived(contrastColorsOverride?.low ?? $contrastColors.low);
+  const activeCustomPaletteNames = $derived(customPaletteNamesOverride ?? $customPaletteNames);
 
   const nonNullPalettesHex = $derived(
     palettesHex
@@ -69,7 +76,11 @@
   const paletteNames = $derived(
     nonNullPalettesHex.length === 0
       ? []
-      : resolveGeneratedPaletteNames(nonNullPalettesHex, effectiveContrastLow, $customPaletteNames)
+      : resolveGeneratedPaletteNames(
+          nonNullPalettesHex,
+          effectiveContrastLow,
+          activeCustomPaletteNames
+        )
   );
 
   let nonNullPaletteNameIndex = $derived.by(() => {
@@ -151,6 +162,18 @@
 
   function handleCopyClick(paletteIndex: number, event: MouseEvent): void {
     const opener = event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+    if (exportPalettesHex) {
+      openExportPreview({ paletteIndex }, 'list', opener, {
+        neutrals: [],
+        palettes: exportPalettesHex,
+        lowContrastColor: effectiveContrastLow,
+        displayNeutrals: [],
+        displayPalettes: exportPalettesDisplay ?? exportPalettesHex,
+        customPaletteNames: customPaletteNamesOverride
+      });
+      return;
+    }
+
     openExportPreview({ paletteIndex }, 'list', opener);
   }
 
@@ -201,14 +224,20 @@
           <div class="palette-block">
             <div class="palette-header">
               <h3 class="palette-title">
-                <PaletteNameEditor
-                  value={$customPaletteNames?.[nameIndex]}
-                  fallbackValue={generatedPaletteNames[nameIndex]}
-                  editButtonAriaLabel={`Edit name for palette ${nameIndex + 1}`}
-                  inputAriaLabel={`Palette ${nameIndex + 1} name`}
-                  data-testid={`generated-palette-name-${paletteIndex}`}
-                  onCommit={(value) => handlePaletteNameCommit(nameIndex, value)}
-                />
+                {#if readonly}
+                  <span data-testid={`generated-palette-name-${paletteIndex}`}>
+                    {paletteNames[nameIndex]}
+                  </span>
+                {:else}
+                  <PaletteNameEditor
+                    value={activeCustomPaletteNames?.[nameIndex]}
+                    fallbackValue={generatedPaletteNames[nameIndex]}
+                    editButtonAriaLabel={`Edit name for palette ${nameIndex + 1}`}
+                    inputAriaLabel={`Palette ${nameIndex + 1} name`}
+                    data-testid={`generated-palette-name-${paletteIndex}`}
+                    onCommit={(value) => handlePaletteNameCommit(nameIndex, value)}
+                  />
+                {/if}
               </h3>
               <div class="palette-header-controls">
                 <div class="hue-nudger">
@@ -248,7 +277,7 @@
                 <Button
                   ariaLabel={`Copy ${paletteNames[nameIndex]} palette`}
                   data-testid={`copy-palette-${paletteIndex}`}
-                  onclick={(e) => handleCopyClick(nameIndex, e)}
+                  onclick={(e) => handleCopyClick(sourcePaletteIndex, e)}
                 >
                   <Icon name="copy" />
                   <span>Copy</span>

--- a/src/lib/components/ReferenceControls.dom.spec.ts
+++ b/src/lib/components/ReferenceControls.dom.spec.ts
@@ -3,7 +3,12 @@ import userEvent from '@testing-library/user-event';
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('$lib/announce', () => ({
+  announce: vi.fn()
+}));
+
 import ReferenceControls from '$lib/components/ReferenceControls.svelte';
+import { announce } from '$lib/announce';
 import {
   colorStore,
   pinReferenceConfiguration,
@@ -33,6 +38,21 @@ describe('ReferenceControls', () => {
       expect(
         screen.queryByRole('button', { name: /restore reference configuration/i })
       ).not.toBeInTheDocument();
+    });
+
+    it('announces when the current palette is pinned as the reference configuration', async () => {
+      expect.assertions(1);
+      const user = userEvent.setup();
+
+      render(ReferenceControls);
+
+      await user.click(
+        screen.getByRole('button', {
+          name: /pin current palette configuration as reference for side-by-side comparison/i
+        })
+      );
+
+      expect(announce).toHaveBeenCalledWith('Reference configuration pinned');
     });
   });
 
@@ -168,6 +188,34 @@ describe('ReferenceControls', () => {
       );
 
       expect(get(referenceConfiguration)).not.toBeNull();
+    });
+
+    it('announces replace, restore, and clear reference actions', async () => {
+      expect.assertions(3);
+      const user = userEvent.setup();
+
+      render(ReferenceControls);
+
+      await user.click(
+        screen.getByRole('button', {
+          name: /replace reference configuration with current palette/i
+        })
+      );
+      expect(announce).toHaveBeenCalledWith('Reference configuration replaced');
+
+      await user.click(
+        screen.getByRole('button', {
+          name: /restore reference configuration into current palette/i
+        })
+      );
+      expect(announce).toHaveBeenCalledWith('Reference configuration restored');
+
+      await user.click(
+        screen.getByRole('button', {
+          name: /clear reference configuration and return to default view/i
+        })
+      );
+      expect(announce).toHaveBeenCalledWith('Reference configuration cleared');
     });
   });
 });

--- a/src/lib/components/ReferenceControls.svelte
+++ b/src/lib/components/ReferenceControls.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { announce } from '$lib/announce';
   import { referenceConfiguration } from '$lib/stores';
   import {
     pinReferenceConfiguration,
@@ -19,21 +20,25 @@
 
   function handlePin(): void {
     pinReferenceConfiguration();
+    announce('Reference configuration pinned');
     onHistoryCommit('Reference pinned');
   }
 
   function handleClear(): void {
     clearReferenceConfiguration();
+    announce('Reference configuration cleared');
     onHistoryCommit('Reference cleared');
   }
 
   function handleReplace(): void {
     replaceReferenceConfiguration();
+    announce('Reference configuration replaced');
     onHistoryCommit('Reference replaced');
   }
 
   function handleRestore(): void {
     restoreReferenceConfiguration();
+    announce('Reference configuration restored');
     onHistoryCommit('Reference restored');
   }
 </script>

--- a/src/lib/components/ReferenceView.dom.spec.ts
+++ b/src/lib/components/ReferenceView.dom.spec.ts
@@ -1,8 +1,10 @@
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import Color from 'colorjs.io';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import ExportPreviewDialog from '$lib/components/ExportPreviewDialog.svelte';
 import ReferenceView from '$lib/components/ReferenceView.svelte';
+import { closeExportPreview } from '$lib/help/exportPreviewStore';
 import { resetColorState, updateColorState } from '$lib/stores';
 
 function toColors(hexes: string[]): Color[] {
@@ -53,6 +55,10 @@ describe('ReferenceView', () => {
     });
   });
 
+  afterEach(() => {
+    closeExportPreview();
+  });
+
   it('shows Added labels on comparison placeholders when the current side has extra structure', () => {
     renderReferenceView();
 
@@ -96,5 +102,77 @@ describe('ReferenceView', () => {
     });
 
     expect(screen.getByText('Contrast down')).toBeInTheDocument();
+  });
+
+  it('keeps naming controls editable only on the current side', () => {
+    renderReferenceView({
+      currentNeutrals: toColors(['#ffffff', '#c9d1d9', '#0d1117']),
+      currentNeutralsHex: ['#ffffff', '#c9d1d9', '#0d1117'],
+      currentNeutralsDisplay: ['#ffffff', '#c9d1d9', '#0d1117'],
+      referenceNeutrals: toColors(['#f9fafb', '#1f2937']),
+      referenceNeutralsHex: ['#f9fafb', '#1f2937'],
+      referenceNeutralsDisplay: ['#f9fafb', '#1f2937'],
+      currentPalettes: [toColors(['#dbeafe', '#60a5fa'])],
+      currentPalettesHex: [['#dbeafe', '#60a5fa']],
+      currentPalettesDisplay: [['#dbeafe', '#60a5fa']],
+      referencePalettes: [toColors(['#dcfce7', '#22c55e'])],
+      referencePalettesHex: [['#dcfce7', '#22c55e']],
+      referencePalettesDisplay: [['#dcfce7', '#22c55e']]
+    });
+
+    expect(screen.getAllByRole('button', { name: /edit name for neutral palette/i })).toHaveLength(
+      1
+    );
+    expect(screen.getAllByRole('button', { name: /edit name for palette 1/i })).toHaveLength(1);
+  });
+
+  it('uses reference palette data when exporting from the reference side', async () => {
+    const currentNeutralsHex = ['#ffffff', '#000000'];
+    const referenceNeutralsHex = ['#f9fafb', '#111827'];
+    const currentPaletteHex = ['#111111', '#222222'];
+    const referencePaletteHex = ['#aaaaaa', '#bbbbbb'];
+    const { container } = renderReferenceView({
+      currentNeutrals: toColors(currentNeutralsHex),
+      currentNeutralsHex,
+      currentNeutralsDisplay: currentNeutralsHex,
+      referenceNeutrals: toColors(referenceNeutralsHex),
+      referenceNeutralsHex,
+      referenceNeutralsDisplay: referenceNeutralsHex,
+      currentPalettes: [toColors(currentPaletteHex)],
+      currentPalettesHex: [currentPaletteHex],
+      currentPalettesDisplay: [currentPaletteHex],
+      referencePalettes: [toColors(referencePaletteHex)],
+      referencePalettesHex: [referencePaletteHex],
+      referencePalettesDisplay: [referencePaletteHex],
+      referenceCustomPaletteNames: ['Reference Accent']
+    });
+
+    render(ExportPreviewDialog, {
+      props: {
+        neutrals: currentNeutralsHex,
+        palettes: [currentPaletteHex],
+        lowContrastColor: '#ffffff',
+        displayNeutrals: currentNeutralsHex,
+        displayPalettes: [currentPaletteHex]
+      }
+    });
+
+    const referenceCopyButton = container.querySelector(
+      '.reference-column [data-testid="copy-palette-0"]'
+    );
+    if (!(referenceCopyButton instanceof HTMLButtonElement)) {
+      throw new Error('Expected reference-side palette copy button');
+    }
+    const referencePaletteName = container.querySelector(
+      '.reference-column [data-testid="generated-palette-name-0"]'
+    );
+    expect(referencePaletteName?.textContent).toContain('Reference Accent');
+
+    await fireEvent.click(referenceCopyButton);
+
+    const preview = await screen.findByTestId('export-preview-content');
+    expect(preview.textContent).toContain('Reference Accent');
+    expect(preview.textContent).toContain('#aaaaaa');
+    expect(preview.textContent).not.toContain('#111111');
   });
 });

--- a/src/lib/components/ReferenceView.svelte
+++ b/src/lib/components/ReferenceView.svelte
@@ -41,6 +41,8 @@
     referencePalettesHex: string[][];
     referencePalettesDisplay: string[][];
     referencePalettesSimulatedDisplay: string[][] | null;
+    referenceCustomNeutralName?: string;
+    referenceCustomPaletteNames?: string[];
     referenceContrastColors?: { low: string; high: string };
     referenceContrastAlgorithm?: ContrastAlgorithm;
     referenceGamutSpace?: GamutSpace;
@@ -67,9 +69,11 @@
     referencePalettesHex,
     referencePalettesDisplay,
     referencePalettesSimulatedDisplay,
+    referenceCustomNeutralName = undefined,
+    referenceCustomPaletteNames = undefined,
     referenceContrastColors = undefined,
-    referenceContrastAlgorithm = 'WCAG',
-    referenceGamutSpace = 'srgb',
+    referenceContrastAlgorithm = undefined,
+    referenceGamutSpace = undefined,
     onCurrentHistoryCommit = () => {}
   }: Props = $props();
 
@@ -87,8 +91,8 @@
 
   const referenceStatusConfig = $derived<ComparisonStatusConfig>({
     contrast: referenceContrastColors ?? currentContrastColors,
-    contrastAlgorithm: referenceContrastAlgorithm,
-    gamutSpace: referenceGamutSpace
+    contrastAlgorithm: referenceContrastAlgorithm ?? currentContrastAlgorithm,
+    gamutSpace: referenceGamutSpace ?? currentGamutSpace
   });
 
   const neutralAlignment = $derived(
@@ -452,6 +456,9 @@
             readonly={true}
             contrastColorsOverride={referenceContrastColors}
             contrastAlgorithmOverride={referenceContrastAlgorithm}
+            customNeutralNameOverride={referenceCustomNeutralName}
+            exportNeutralsHex={referenceNeutralsHex}
+            exportNeutralsDisplay={referenceNeutralsDisplay}
           />
           <PaletteGrid
             palettes={referencePaletteColors}
@@ -466,6 +473,9 @@
             readonly={true}
             contrastColorsOverride={referenceContrastColors}
             contrastAlgorithmOverride={referenceContrastAlgorithm}
+            customPaletteNamesOverride={referenceCustomPaletteNames}
+            exportPalettesHex={referencePalettesHex}
+            exportPalettesDisplay={referencePalettesDisplay}
           />
         </div>
       </div>

--- a/src/lib/help/exportPreviewStore.ts
+++ b/src/lib/help/exportPreviewStore.ts
@@ -4,18 +4,30 @@ export type ExportFormat = 'list' | 'json' | 'css' | 'scss';
 
 export type ExportScope = 'all' | 'neutral' | { paletteIndex: number };
 
+export interface ExportPreviewData {
+  neutrals: string[];
+  palettes: string[][];
+  lowContrastColor?: string;
+  displayNeutrals?: string[];
+  displayPalettes?: string[][];
+  customNeutralName?: string;
+  customPaletteNames?: string[];
+}
+
 export interface ExportPreviewState {
   open: boolean;
   opener: HTMLElement | null;
   scope: ExportScope;
   initialFormat: ExportFormat;
+  dataOverride: ExportPreviewData | null;
 }
 
 const INITIAL_STATE: ExportPreviewState = {
   open: false,
   opener: null,
   scope: 'all',
-  initialFormat: 'list'
+  initialFormat: 'list',
+  dataOverride: null
 };
 
 export const exportPreviewDialog = writable<ExportPreviewState>({ ...INITIAL_STATE });
@@ -23,13 +35,15 @@ export const exportPreviewDialog = writable<ExportPreviewState>({ ...INITIAL_STA
 export function openExportPreview(
   scope: ExportScope,
   initialFormat: ExportFormat,
-  opener: HTMLElement | null = null
+  opener: HTMLElement | null = null,
+  dataOverride: ExportPreviewData | null = null
 ): void {
   exportPreviewDialog.set({
     open: true,
     opener,
     scope,
-    initialFormat
+    initialFormat,
+    dataOverride
   });
 }
 

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -65,6 +65,7 @@ export interface HistorySnapshot {
   constraintSolverSummary?: ConstraintSolverSummary | null;
   comparisonMetric?: ColorDifferenceMetric;
   swatchChangeThreshold?: number;
+  swatchChangeThresholdsByMetric?: Partial<Record<ColorDifferenceMetric, number>>;
 }
 
 export interface HistoryEntryMeta {

--- a/src/lib/referenceColorGeneration.spec.ts
+++ b/src/lib/referenceColorGeneration.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  generateColorsFromReference,
+  type ReferenceRenderSettings
+} from './referenceColorGeneration';
+import type { ReferenceConfiguration } from './referenceConfiguration';
+
+function createReferenceConfiguration(
+  overrides: Partial<ReferenceConfiguration> = {}
+): ReferenceConfiguration {
+  return {
+    pinnedAt: Date.now(),
+    baseColor: '#5EF784',
+    warmth: -7,
+    warmthHue: 142,
+    chromaMultiplier: 1,
+    numColors: 11,
+    numPalettes: 11,
+    x1: 0.16,
+    y1: 0,
+    x2: 0.28,
+    y2: 0.38,
+    lightnessNudgers: Array.from({ length: 11 }, () => 0),
+    hueNudgers: Array.from({ length: 11 }, () => 0),
+    stepSaturationNudgers: Array.from({ length: 11 }, () => 0),
+    paletteSaturationNudgers: Array.from({ length: 11 }, () => 0),
+    paletteChromaNudgers: Array.from({ length: 11 }, () => 1),
+    contrastMode: 'auto',
+    lowStep: 0,
+    highStep: 10,
+    lowReference: { kind: 'neutral', stepIndex: 0 },
+    highReference: { kind: 'neutral', stepIndex: 10 },
+    contrast: { low: '#ffffff', high: '#000000' },
+    solveAdjacentStopLows: true,
+    themePreference: 'auto',
+    resolvedTheme: 'light',
+    customNeutralName: undefined,
+    customPaletteNames: undefined,
+    constraints: [],
+    ...overrides
+  };
+}
+
+function createRenderSettings(
+  overrides: Partial<ReferenceRenderSettings> = {}
+): ReferenceRenderSettings {
+  return {
+    cvdMode: 'none',
+    displayColorSpace: 'hex',
+    gamutSpace: 'srgb',
+    ...overrides
+  };
+}
+
+describe('referenceColorGeneration', () => {
+  it('uses the pinned resolved theme to generate the frozen baseline', () => {
+    const lightReference = createReferenceConfiguration({ resolvedTheme: 'light' });
+    const darkReference = createReferenceConfiguration({ resolvedTheme: 'dark' });
+
+    const lightResult = generateColorsFromReference(lightReference, createRenderSettings());
+    const darkResult = generateColorsFromReference(darkReference, createRenderSettings());
+
+    expect(lightResult.neutralsHex[0]).not.toBe(darkResult.neutralsHex[0]);
+    expect(lightResult.neutralsHex.at(-1)).not.toBe(darkResult.neutralsHex.at(-1));
+  });
+
+  it('applies shared display settings at read time instead of freezing them in the reference', () => {
+    const reference = createReferenceConfiguration();
+
+    const hexResult = generateColorsFromReference(
+      reference,
+      createRenderSettings({ displayColorSpace: 'hex', gamutSpace: 'srgb' })
+    );
+    const oklchResult = generateColorsFromReference(
+      reference,
+      createRenderSettings({ displayColorSpace: 'oklch', gamutSpace: 'p3' })
+    );
+
+    expect(hexResult.neutralsDisplay[0]).toMatch(/^#/);
+    expect(oklchResult.neutralsDisplay[0]).toContain('oklch(');
+  });
+});

--- a/src/lib/referenceColorGeneration.ts
+++ b/src/lib/referenceColorGeneration.ts
@@ -6,6 +6,7 @@ import { generatePalettes, type ColorGenParams } from '$lib/colorUtils';
 import { colorToCssHex, colorToCssRender, colorToCssSwatchRender } from '$lib/colorUtils';
 import type Color from 'colorjs.io';
 import type { ReferenceConfiguration } from './referenceConfiguration';
+import type { CvdMode, DisplayColorSpace, GamutSpace } from './types';
 
 /**
  * Generated colors from a reference configuration
@@ -23,11 +24,17 @@ export interface ReferenceGeneratedColors {
   palettesSimulatedDisplay: string[][] | null;
 }
 
+export interface ReferenceRenderSettings {
+  cvdMode?: CvdMode;
+  displayColorSpace: DisplayColorSpace;
+  gamutSpace: GamutSpace;
+}
+
 export function generateColorsFromReference(
   reference: ReferenceConfiguration,
-  cvdMode: 'none' | 'protanopia' | 'deuteranopia' | 'tritanopia' | 'achromatopsia' = 'none',
-  currentTheme: 'light' | 'dark' = 'light'
+  settings: ReferenceRenderSettings
 ): ReferenceGeneratedColors {
+  const { cvdMode = 'none', displayColorSpace, gamutSpace } = settings;
   const params: ColorGenParams = {
     numColors: reference.numColors,
     numPalettes: reference.numPalettes,
@@ -39,13 +46,13 @@ export function generateColorsFromReference(
     x2: reference.x2,
     y2: reference.y2,
     chromaMultiplier: reference.chromaMultiplier,
-    currentTheme,
+    currentTheme: reference.resolvedTheme,
     lightnessNudgers: reference.lightnessNudgers,
     hueNudgers: reference.hueNudgers,
     stepSaturationNudgers: reference.stepSaturationNudgers,
     paletteSaturationNudgers: reference.paletteSaturationNudgers,
     paletteChromaNudgers: reference.paletteChromaNudgers,
-    gamutSpace: reference.gamutSpace
+    gamutSpace
   };
 
   const result = generatePalettes(params);
@@ -55,36 +62,28 @@ export function generateColorsFromReference(
   const neutralsHex = neutrals.map((c) => colorToCssHex(c));
   const palettesHex = palettes.map((palette) => palette.map((c) => colorToCssHex(c)));
 
-  const neutralsDisplay = neutrals.map((c) =>
-    colorToCssRender(c, reference.displayColorSpace, reference.gamutSpace)
-  );
+  const neutralsDisplay = neutrals.map((c) => colorToCssRender(c, displayColorSpace, gamutSpace));
   const palettesDisplay = palettes.map((palette) =>
-    palette.map((c) => colorToCssRender(c, reference.displayColorSpace, reference.gamutSpace))
+    palette.map((c) => colorToCssRender(c, displayColorSpace, gamutSpace))
   );
 
   const neutralsSwatchDisplay = neutrals.map((c) =>
-    colorToCssSwatchRender(c, reference.displayColorSpace, reference.gamutSpace, 4)
+    colorToCssSwatchRender(c, displayColorSpace, gamutSpace, 4)
   );
   const palettesSwatchDisplay = palettes.map((palette) =>
-    palette.map((c) =>
-      colorToCssSwatchRender(c, reference.displayColorSpace, reference.gamutSpace, 4)
-    )
+    palette.map((c) => colorToCssSwatchRender(c, displayColorSpace, gamutSpace, 4))
   );
 
   const neutralsSimulatedDisplay =
     cvdMode === 'none'
       ? null
-      : neutrals.map((c) =>
-          colorToCssRender(c, reference.displayColorSpace, reference.gamutSpace, cvdMode)
-        );
+      : neutrals.map((c) => colorToCssRender(c, displayColorSpace, gamutSpace, cvdMode));
 
   const palettesSimulatedDisplay =
     cvdMode === 'none'
       ? null
       : palettes.map((palette) =>
-          palette.map((c) =>
-            colorToCssRender(c, reference.displayColorSpace, reference.gamutSpace, cvdMode)
-          )
+          palette.map((c) => colorToCssRender(c, displayColorSpace, gamutSpace, cvdMode))
         );
 
   return {

--- a/src/lib/referenceConfiguration.ts
+++ b/src/lib/referenceConfiguration.ts
@@ -1,5 +1,5 @@
 import type { ColorState } from './stores';
-import type { ContrastReference } from './types';
+import type { Constraint, ContrastReference, ThemePreference } from './types';
 
 export interface ReferenceConfiguration {
   pinnedAt: number;
@@ -28,17 +28,12 @@ export interface ReferenceConfiguration {
   highReference: ContrastReference;
   contrast: { low: string; high: string };
   solveAdjacentStopLows: boolean;
-
-  displayColorSpace: ColorState['displayColorSpace'];
-  gamutSpace: ColorState['gamutSpace'];
-  swatchLabels: ColorState['swatchLabels'];
-  showSwatchGamutWarnings: boolean;
-  showSwatchContrastIndicators: boolean;
-  swatchContrastIndicators: ColorState['swatchContrastIndicators'];
-  contrastAlgorithm: ColorState['contrastAlgorithm'];
+  themePreference: ThemePreference;
+  resolvedTheme: ColorState['currentTheme'];
 
   customNeutralName?: string;
   customPaletteNames?: string[];
+  constraints: Constraint[];
 }
 
 export function createReferenceConfiguration(colorState: ColorState): ReferenceConfiguration {
@@ -66,16 +61,12 @@ export function createReferenceConfiguration(colorState: ColorState): ReferenceC
     highReference: structuredClone(colorState.highReference),
     contrast: { low: colorState.contrast.low, high: colorState.contrast.high },
     solveAdjacentStopLows: colorState.solveAdjacentStopLows,
-    displayColorSpace: colorState.displayColorSpace,
-    gamutSpace: colorState.gamutSpace,
-    swatchLabels: colorState.swatchLabels,
-    showSwatchGamutWarnings: colorState.showSwatchGamutWarnings,
-    showSwatchContrastIndicators: colorState.showSwatchContrastIndicators,
-    swatchContrastIndicators: structuredClone(colorState.swatchContrastIndicators),
-    contrastAlgorithm: colorState.contrastAlgorithm,
+    themePreference: colorState.themePreference,
+    resolvedTheme: colorState.currentTheme,
     customNeutralName: colorState.customNeutralName,
     customPaletteNames: colorState.customPaletteNames
       ? [...colorState.customPaletteNames]
-      : undefined
+      : undefined,
+    constraints: structuredClone(colorState.constraints)
   };
 }

--- a/src/lib/referenceWorkspace.ts
+++ b/src/lib/referenceWorkspace.ts
@@ -5,4 +5,5 @@ export interface ReferenceWorkspaceSnapshot {
   viewMode: 'default' | 'reference' | 'comparison';
   comparisonMetric: ColorDifferenceMetric;
   swatchChangeThreshold: number;
+  swatchChangeThresholdsByMetric?: Partial<Record<ColorDifferenceMetric, number>>;
 }

--- a/src/lib/referenceWorkspacePersistence.dom.spec.ts
+++ b/src/lib/referenceWorkspacePersistence.dom.spec.ts
@@ -1,11 +1,17 @@
+import { get } from 'svelte/store';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
+import {
+  createReferenceConfiguration,
+  type ReferenceConfiguration
+} from './referenceConfiguration';
 import {
   saveReferenceWorkspaceToStorage,
   loadReferenceWorkspaceFromStorage,
   clearStoredReferenceWorkspace
 } from './referenceWorkspacePersistence';
 import type { StoredReferenceWorkspace } from './referenceWorkspacePersistence';
+import { colorStore, resetColorState } from './stores';
 
 const STORAGE_KEY = 'chroma11y-reference-workspace';
 
@@ -17,6 +23,16 @@ function createWorkspaceState(
     viewMode: 'default',
     comparisonMetric: 'ok',
     swatchChangeThreshold: 1,
+    ...overrides
+  };
+}
+
+function createStoredReferenceConfiguration(
+  overrides: Partial<ReferenceConfiguration> = {}
+): ReferenceConfiguration {
+  resetColorState('light');
+  return {
+    ...createReferenceConfiguration(get(colorStore)),
     ...overrides
   };
 }
@@ -35,7 +51,10 @@ describe('referenceWorkspacePersistence', () => {
       expect.assertions(1);
 
       const state = createWorkspaceState({
-        referenceConfiguration: { baseColor: '#5EF784', numColors: 11 },
+        referenceConfiguration: createStoredReferenceConfiguration() as unknown as Record<
+          string,
+          unknown
+        >,
         viewMode: 'reference'
       });
 
@@ -68,7 +87,10 @@ describe('referenceWorkspacePersistence', () => {
       expect.assertions(2);
 
       const state = createWorkspaceState({
-        referenceConfiguration: { baseColor: '#5EF784', numColors: 11 },
+        referenceConfiguration: createStoredReferenceConfiguration() as unknown as Record<
+          string,
+          unknown
+        >,
         viewMode: 'reference',
         comparisonMetric: '2000',
         swatchChangeThreshold: 5
@@ -77,8 +99,62 @@ describe('referenceWorkspacePersistence', () => {
 
       const result = loadReferenceWorkspaceFromStorage();
 
-      expect(result?.referenceConfiguration).toEqual({ baseColor: '#5EF784', numColors: 11 });
+      expect(result?.referenceConfiguration).toEqual(state.referenceConfiguration);
       expect(result?.viewMode).toBe('reference');
+    });
+
+    it('drops legacy reference configurations that are missing required frozen-theme fields', () => {
+      expect.assertions(4);
+
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          ...createWorkspaceState({
+            referenceConfiguration: { baseColor: '#5EF784', numColors: 11 },
+            viewMode: 'comparison',
+            comparisonMetric: '2000',
+            swatchChangeThreshold: 3
+          }),
+          swatchChangeThresholdsByMetric: {
+            ok: 0.04,
+            '2000': 3
+          }
+        })
+      );
+
+      const result = loadReferenceWorkspaceFromStorage();
+
+      expect(result?.referenceConfiguration).toBeNull();
+      expect(result?.viewMode).toBe('default');
+      expect(result?.comparisonMetric).toBe('2000');
+      expect(result?.swatchChangeThreshold).toBe(3);
+    });
+
+    it('restores remembered swatch thresholds for each comparison metric', () => {
+      expect.assertions(1);
+
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          ...createWorkspaceState({
+            comparisonMetric: 'ok',
+            swatchChangeThreshold: 0.04
+          }),
+          swatchChangeThresholdsByMetric: {
+            ok: 0.04,
+            '2000': 3
+          }
+        })
+      );
+
+      const result = loadReferenceWorkspaceFromStorage();
+
+      expect(result).toMatchObject({
+        swatchChangeThresholdsByMetric: {
+          ok: 0.04,
+          '2000': 3
+        }
+      });
     });
 
     it('returns null when nothing is stored', () => {

--- a/src/lib/referenceWorkspacePersistence.ts
+++ b/src/lib/referenceWorkspacePersistence.ts
@@ -6,7 +6,8 @@
  */
 
 import type { ReferenceWorkspaceSnapshot } from './referenceWorkspace';
-import type { ColorDifferenceMetric } from './types';
+import type { ReferenceConfiguration } from './referenceConfiguration';
+import type { ColorDifferenceMetric, ContrastReference } from './types';
 
 export type StoredReferenceWorkspace = ReferenceWorkspaceSnapshot;
 
@@ -18,12 +19,113 @@ const VALID_VIEW_MODES: Array<'default' | 'reference' | 'comparison'> = [
   'comparison'
 ];
 const VALID_COMPARISON_METRICS: ColorDifferenceMetric[] = ['ok', '2000'];
+const DEFAULT_SWATCH_CHANGE_THRESHOLDS_BY_METRIC: Record<ColorDifferenceMetric, number> = {
+  ok: 0.02,
+  '2000': 2
+};
 
 /**
  * Type guard for validating ColorDifferenceMetric
  */
 function isValidComparisonMetric(value: unknown): value is ColorDifferenceMetric {
   return VALID_COMPARISON_METRICS.includes(value as ColorDifferenceMetric);
+}
+
+function isValidThresholdsByMetric(
+  value: unknown
+): value is Partial<Record<ColorDifferenceMetric, number>> {
+  if (value === undefined) return true;
+  if (typeof value !== 'object' || value === null) return false;
+
+  const candidate = value as Record<string, unknown>;
+  for (const metric of VALID_COMPARISON_METRICS) {
+    if (candidate[metric] !== undefined && typeof candidate[metric] !== 'number') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isValidThemePreference(value: unknown): value is 'auto' | 'light' | 'dark' {
+  return value === 'auto' || value === 'light' || value === 'dark';
+}
+
+function isValidResolvedTheme(value: unknown): value is 'light' | 'dark' {
+  return value === 'light' || value === 'dark';
+}
+
+function isValidNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'number');
+}
+
+function isValidStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
+function isValidContrastReference(value: unknown): value is ContrastReference {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (candidate.kind !== 'neutral' && candidate.kind !== 'palette') {
+    return false;
+  }
+
+  if (typeof candidate.stepIndex !== 'number') {
+    return false;
+  }
+
+  if (candidate.kind === 'palette' && typeof candidate.paletteIndex !== 'number') {
+    return false;
+  }
+
+  return true;
+}
+
+function isValidReferenceConfiguration(value: unknown): value is ReferenceConfiguration {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+
+  return (
+    typeof candidate.pinnedAt === 'number' &&
+    typeof candidate.baseColor === 'string' &&
+    typeof candidate.warmth === 'number' &&
+    (candidate.warmthHue === undefined || typeof candidate.warmthHue === 'number') &&
+    typeof candidate.chromaMultiplier === 'number' &&
+    typeof candidate.numColors === 'number' &&
+    typeof candidate.numPalettes === 'number' &&
+    typeof candidate.x1 === 'number' &&
+    typeof candidate.y1 === 'number' &&
+    typeof candidate.x2 === 'number' &&
+    typeof candidate.y2 === 'number' &&
+    isValidNumberArray(candidate.lightnessNudgers) &&
+    isValidNumberArray(candidate.hueNudgers) &&
+    isValidNumberArray(candidate.stepSaturationNudgers) &&
+    isValidNumberArray(candidate.paletteSaturationNudgers) &&
+    isValidNumberArray(candidate.paletteChromaNudgers) &&
+    (candidate.contrastMode === 'auto' || candidate.contrastMode === 'manual') &&
+    typeof candidate.lowStep === 'number' &&
+    typeof candidate.highStep === 'number' &&
+    isValidContrastReference(candidate.lowReference) &&
+    isValidContrastReference(candidate.highReference) &&
+    typeof candidate.contrast === 'object' &&
+    candidate.contrast !== null &&
+    typeof (candidate.contrast as Record<string, unknown>).low === 'string' &&
+    typeof (candidate.contrast as Record<string, unknown>).high === 'string' &&
+    typeof candidate.solveAdjacentStopLows === 'boolean' &&
+    isValidThemePreference(candidate.themePreference) &&
+    isValidResolvedTheme(candidate.resolvedTheme) &&
+    (candidate.customNeutralName === undefined ||
+      typeof candidate.customNeutralName === 'string') &&
+    (candidate.customPaletteNames === undefined ||
+      isValidStringArray(candidate.customPaletteNames)) &&
+    Array.isArray(candidate.constraints)
+  );
 }
 
 /**
@@ -66,7 +168,40 @@ function isValidStoredReferenceWorkspace(value: unknown): value is StoredReferen
     return false;
   }
 
+  if (!isValidThresholdsByMetric(candidate.swatchChangeThresholdsByMetric)) {
+    return false;
+  }
+
   return true;
+}
+
+function migrateStoredReferenceWorkspace(
+  value: StoredReferenceWorkspace
+): StoredReferenceWorkspace {
+  const referenceConfiguration = isValidReferenceConfiguration(value.referenceConfiguration)
+    ? value.referenceConfiguration
+    : null;
+  const swatchChangeThresholdsByMetric = value.swatchChangeThresholdsByMetric
+    ? {
+        ok: Math.max(
+          0,
+          value.swatchChangeThresholdsByMetric.ok ?? DEFAULT_SWATCH_CHANGE_THRESHOLDS_BY_METRIC.ok
+        ),
+        '2000': Math.max(
+          0,
+          value.swatchChangeThresholdsByMetric['2000'] ??
+            DEFAULT_SWATCH_CHANGE_THRESHOLDS_BY_METRIC['2000']
+        )
+      }
+    : { ...DEFAULT_SWATCH_CHANGE_THRESHOLDS_BY_METRIC };
+
+  return {
+    referenceConfiguration,
+    viewMode: referenceConfiguration ? value.viewMode : 'default',
+    comparisonMetric: value.comparisonMetric,
+    swatchChangeThreshold: swatchChangeThresholdsByMetric[value.comparisonMetric],
+    swatchChangeThresholdsByMetric
+  };
 }
 
 /**
@@ -98,7 +233,7 @@ export function loadReferenceWorkspaceFromStorage(): StoredReferenceWorkspace | 
       return null;
     }
 
-    return parsed;
+    return migrateStoredReferenceWorkspace(parsed);
   } catch (error) {
     console.warn('Failed to load reference workspace from localStorage:', error);
     return null;

--- a/src/lib/stores.spec.ts
+++ b/src/lib/stores.spec.ts
@@ -47,9 +47,13 @@ import {
   neutralsSwatchDisplay,
   palettesSwatchDisplay,
   referenceConfiguration,
+  comparisonMetric,
+  swatchChangeThreshold,
   updateColorState,
   setTheme,
   setThemePreference,
+  setComparisonMetric,
+  setSwatchChangeThreshold,
   updateLightnessNudger,
   updateHueNudger,
   updateContrastFromNeutrals,
@@ -219,6 +223,32 @@ describe('stores', () => {
       expect(get(constraints)).toEqual([]);
       expect(get(solverAdjustmentSnapshot)).toBeNull();
       expect(get(constraintSolverSummary)).toBeNull();
+    });
+
+    it('comparison settings default to Delta E OK with its default threshold', () => {
+      expect.assertions(2);
+      expect(get(comparisonMetric)).toBe('ok');
+      expect(get(swatchChangeThreshold)).toBe(0.02);
+    });
+  });
+
+  describe('comparison settings', () => {
+    it('restores the remembered swatch change threshold for each comparison metric', () => {
+      expect.assertions(5);
+
+      setSwatchChangeThreshold(0.04);
+      expect(get(swatchChangeThreshold)).toBe(0.04);
+
+      setComparisonMetric('2000');
+      expect(get(comparisonMetric)).toBe('2000');
+      expect(get(swatchChangeThreshold)).toBe(2);
+
+      setSwatchChangeThreshold(3);
+      setComparisonMetric('ok');
+      expect(get(swatchChangeThreshold)).toBe(0.04);
+
+      setComparisonMetric('2000');
+      expect(get(swatchChangeThreshold)).toBe(3);
     });
   });
 
@@ -716,7 +746,7 @@ describe('stores', () => {
     });
 
     it('pinReferenceConfiguration captures all core parameters', () => {
-      expect.assertions(8);
+      expect.assertions(6);
       updateColorState({
         baseColor: '#FF0000',
         warmth: 5,
@@ -733,9 +763,49 @@ describe('stores', () => {
       expect(ref?.chromaMultiplier).toBe(0.8);
       expect(ref?.numColors).toBe(9);
       expect(ref?.numPalettes).toBe(6);
-      expect(ref?.displayColorSpace).toBeDefined();
-      expect(ref?.gamutSpace).toBeDefined();
       expect(ref?.pinnedAt).toBeDefined();
+    });
+
+    it('pinReferenceConfiguration captures authored theme and constraints but excludes shared inspection settings', () => {
+      expect.assertions(8);
+
+      updateColorState({
+        themePreference: 'auto',
+        currentTheme: 'dark',
+        displayColorSpace: 'oklch',
+        gamutSpace: 'p3',
+        contrastAlgorithm: 'APCA',
+        swatchLabels: 'none',
+        constraints: [
+          {
+            id: 'constraint-1',
+            type: 'target-color',
+            enabled: true,
+            targetHex: '#5EF784',
+            metric: 'ok'
+          }
+        ]
+      });
+
+      pinReferenceConfiguration();
+
+      const ref = get(referenceConfiguration);
+      expect(ref?.themePreference).toBe('auto');
+      expect(ref?.resolvedTheme).toBe('dark');
+      expect(ref?.constraints).toEqual([
+        {
+          id: 'constraint-1',
+          type: 'target-color',
+          enabled: true,
+          targetHex: '#5EF784',
+          metric: 'ok'
+        }
+      ]);
+      expect('displayColorSpace' in (ref ?? {})).toBe(false);
+      expect('gamutSpace' in (ref ?? {})).toBe(false);
+      expect('swatchLabels' in (ref ?? {})).toBe(false);
+      expect('showSwatchGamutWarnings' in (ref ?? {})).toBe(false);
+      expect('contrastAlgorithm' in (ref ?? {})).toBe(false);
     });
 
     it('clearReferenceConfiguration sets it to null', () => {
@@ -807,6 +877,39 @@ describe('stores', () => {
       expect(colorState.baseColor).toBe('#FF0000');
       expect(colorState.numColors).toBe(9);
       expect(get(referenceConfiguration)).not.toBeNull();
+    });
+
+    it('restoreReferenceConfiguration reproduces the pinned theme while preserving shared inspection settings', () => {
+      expect.assertions(6);
+
+      updateColorState({
+        themePreference: 'auto',
+        currentTheme: 'light',
+        displayColorSpace: 'hex',
+        gamutSpace: 'srgb',
+        swatchLabels: 'both',
+        contrastAlgorithm: 'WCAG'
+      });
+      pinReferenceConfiguration();
+
+      updateColorState({
+        themePreference: 'dark',
+        currentTheme: 'dark',
+        displayColorSpace: 'oklch',
+        gamutSpace: 'p3',
+        swatchLabels: 'none',
+        contrastAlgorithm: 'APCA'
+      });
+
+      restoreReferenceConfiguration();
+
+      const colorState = get(colorStore);
+      expect(colorState.themePreference).toBe('auto');
+      expect(colorState.currentTheme).toBe('light');
+      expect(colorState.displayColorSpace).toBe('oklch');
+      expect(colorState.gamutSpace).toBe('p3');
+      expect(colorState.swatchLabels).toBe('none');
+      expect(colorState.contrastAlgorithm).toBe('APCA');
     });
 
     it('restoreReferenceConfiguration is a no-op when no reference is pinned', () => {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -3,6 +3,7 @@ import type Color from 'colorjs.io';
 import { colorToCssHex, colorToCssRender, colorToCssSwatchRender } from '$lib/colorUtils';
 import { normalizeCustomPaletteName, normalizeCustomPaletteNames } from '$lib/paletteNameUtils';
 import { createReferenceConfiguration } from '$lib/referenceConfiguration';
+import { themePresets } from '$lib/themePresets';
 import type {
   DisplayColorSpace,
   GamutSpace,
@@ -71,6 +72,7 @@ export interface ColorState {
   referenceConfiguration: ReferenceConfiguration | null;
   comparisonMetric: ColorDifferenceMetric;
   swatchChangeThreshold: number;
+  swatchChangeThresholdsByMetric: Record<ColorDifferenceMetric, number>;
   _lastUpdated?: number;
 }
 
@@ -78,6 +80,16 @@ export interface ActiveSwatchPicker {
   kind: 'contrast-reference' | 'constraint-target';
   target: 'low' | 'high' | string;
 }
+
+export const autoThemeRestoreLock = writable<'light' | 'dark' | null>(null);
+
+export const setAutoThemeRestoreLock = (theme: 'light' | 'dark' | null) => {
+  autoThemeRestoreLock.set(theme);
+};
+
+export const clearAutoThemeRestoreLock = () => {
+  autoThemeRestoreLock.set(null);
+};
 
 function createNeutralContrastReference(stepIndex: number): ContrastReference {
   return {
@@ -87,56 +99,10 @@ function createNeutralContrastReference(stepIndex: number): ContrastReference {
 }
 
 /**
- * Default color state values for light and dark modes
- */
-const THEME_PRESETS = {
-  light: {
-    numColors: 11,
-    numPalettes: 11,
-    baseColor: '#5EF784',
-    warmth: -7,
-    x1: 0.16,
-    y1: 0.0,
-    x2: 0.28,
-    y2: 0.38,
-    chromaMultiplier: 1,
-    contrastMode: 'auto' as const,
-    lowStep: 0,
-    highStep: 10,
-    lowReference: createNeutralContrastReference(0),
-    highReference: createNeutralContrastReference(10),
-    contrast: {
-      low: '#ffffff',
-      high: '#000000'
-    }
-  },
-  dark: {
-    numColors: 11,
-    numPalettes: 11,
-    baseColor: '#5EF784',
-    warmth: -7,
-    x1: 0.45,
-    y1: 0.08,
-    x2: 0.77,
-    y2: 0.96,
-    chromaMultiplier: 0.83,
-    contrastMode: 'auto' as const,
-    lowStep: 2,
-    highStep: 10,
-    lowReference: createNeutralContrastReference(2),
-    highReference: createNeutralContrastReference(10),
-    contrast: {
-      low: '#071531',
-      high: '#ffffff'
-    }
-  }
-};
-
-/**
  * Default color state values
  */
 const DEFAULT_STATE = {
-  ...THEME_PRESETS.light,
+  ...themePresets.light,
   neutrals: [] as Color[],
   palettes: [] as Color[][],
   lightnessNudgers: [] as number[],
@@ -168,12 +134,45 @@ const DEFAULT_STATE = {
   constraintSolverSummary: null as ConstraintSolverSummary | null,
   referenceConfiguration: null as ReferenceConfiguration | null,
   comparisonMetric: 'ok' as ColorDifferenceMetric,
-  swatchChangeThreshold: 0.02
+  swatchChangeThreshold: 0.02,
+  swatchChangeThresholdsByMetric: {
+    ok: 0.02,
+    '2000': 2
+  } as Record<ColorDifferenceMetric, number>
 };
 
+const DEFAULT_SWATCH_CHANGE_THRESHOLDS_BY_METRIC: Record<ColorDifferenceMetric, number> =
+  structuredClone(DEFAULT_STATE.swatchChangeThresholdsByMetric);
+
+function normalizeSwatchChangeThresholdsByMetric(
+  thresholds: Partial<Record<ColorDifferenceMetric, number>> | undefined,
+  comparisonMetric: ColorDifferenceMetric,
+  swatchChangeThreshold: number
+): Record<ColorDifferenceMetric, number> {
+  const normalizedThreshold = Math.max(0, swatchChangeThreshold);
+
+  return {
+    ok:
+      comparisonMetric === 'ok'
+        ? normalizedThreshold
+        : Math.max(0, thresholds?.ok ?? DEFAULT_SWATCH_CHANGE_THRESHOLDS_BY_METRIC.ok),
+    '2000':
+      comparisonMetric === '2000'
+        ? normalizedThreshold
+        : Math.max(0, thresholds?.['2000'] ?? DEFAULT_SWATCH_CHANGE_THRESHOLDS_BY_METRIC['2000'])
+  };
+}
+
 function normalizeDisplayState(state: ColorState): ColorState {
+  const normalizedSwatchChangeThreshold = Math.max(0, state.swatchChangeThreshold);
   const normalizedState: ColorState = {
     ...state,
+    swatchChangeThreshold: normalizedSwatchChangeThreshold,
+    swatchChangeThresholdsByMetric: normalizeSwatchChangeThresholdsByMetric(
+      state.swatchChangeThresholdsByMetric,
+      state.comparisonMetric,
+      normalizedSwatchChangeThreshold
+    ),
     lowReference: state.lowReference ?? createNeutralContrastReference(state.lowStep),
     highReference: state.highReference ?? createNeutralContrastReference(state.highStep),
     customNeutralName: normalizeCustomPaletteName(state.customNeutralName),
@@ -478,13 +477,13 @@ function resolveContrastReferenceHex(
  * This is called when the resolved theme changes (either from explicit preference or auto detection).
  */
 export const setTheme = (theme: 'light' | 'dark') => {
-  if (!THEME_PRESETS[theme]) {
+  if (!themePresets[theme]) {
     console.error(`Invalid theme: ${theme}. Must be 'light' or 'dark'`);
     return;
   }
 
   colorStore.update((currentState) => {
-    const themePreset = THEME_PRESETS[theme];
+    const themePreset = themePresets[theme];
     return normalizeDisplayState({
       ...currentState,
       ...themePreset,
@@ -500,10 +499,11 @@ export const setTheme = (theme: 'light' | 'dark') => {
  * When 'light' or 'dark', also applies the theme preset immediately.
  */
 export const setThemePreference = (preference: ThemePreference) => {
+  clearAutoThemeRestoreLock();
   colorStore.update((currentState) => {
     const newState = { ...currentState, themePreference: preference };
     if (preference !== 'auto') {
-      const themePreset = THEME_PRESETS[preference];
+      const themePreset = themePresets[preference];
       return normalizeDisplayState({
         ...newState,
         ...themePreset,
@@ -674,6 +674,7 @@ export const pinReferenceConfiguration = () => {
 };
 
 export const clearReferenceConfiguration = () => {
+  clearAutoThemeRestoreLock();
   colorStore.update((currentState) => ({
     ...currentState,
     referenceConfiguration: null
@@ -691,9 +692,14 @@ export const replaceReferenceConfiguration = () => {
 };
 
 export const restoreReferenceConfiguration = () => {
+  let nextAutoThemeRestoreLock: 'light' | 'dark' | null = null;
+
   colorStore.update((currentState) => {
     const ref = currentState.referenceConfiguration;
     if (!ref) return currentState;
+
+    nextAutoThemeRestoreLock = ref.themePreference === 'auto' ? ref.resolvedTheme : null;
+
     return normalizeDisplayState({
       ...currentState,
       baseColor: ref.baseColor,
@@ -718,32 +724,39 @@ export const restoreReferenceConfiguration = () => {
       highReference: structuredClone(ref.highReference),
       contrast: { low: ref.contrast.low, high: ref.contrast.high },
       solveAdjacentStopLows: ref.solveAdjacentStopLows,
-      displayColorSpace: ref.displayColorSpace,
-      gamutSpace: ref.gamutSpace,
-      swatchLabels: ref.swatchLabels,
-      showSwatchGamutWarnings: ref.showSwatchGamutWarnings,
-      showSwatchContrastIndicators: ref.showSwatchContrastIndicators,
-      swatchContrastIndicators: structuredClone(ref.swatchContrastIndicators),
-      contrastAlgorithm: ref.contrastAlgorithm,
+      themePreference: ref.themePreference,
+      currentTheme: ref.resolvedTheme,
       customNeutralName: ref.customNeutralName,
       customPaletteNames: ref.customPaletteNames ? [...ref.customPaletteNames] : undefined,
+      constraints: structuredClone(ref.constraints),
       _lastUpdated: Date.now()
     });
   });
+
+  setAutoThemeRestoreLock(nextAutoThemeRestoreLock);
 };
 
 export const setComparisonMetric = (metric: ColorDifferenceMetric) => {
   colorStore.update((currentState) => ({
     ...currentState,
-    comparisonMetric: metric
+    comparisonMetric: metric,
+    swatchChangeThreshold: currentState.swatchChangeThresholdsByMetric[metric]
   }));
 };
 
 export const setSwatchChangeThreshold = (threshold: number) => {
-  colorStore.update((currentState) => ({
-    ...currentState,
-    swatchChangeThreshold: Math.max(0, threshold)
-  }));
+  colorStore.update((currentState) => {
+    const nextThreshold = Math.max(0, threshold);
+
+    return {
+      ...currentState,
+      swatchChangeThreshold: nextThreshold,
+      swatchChangeThresholdsByMetric: {
+        ...currentState.swatchChangeThresholdsByMetric,
+        [currentState.comparisonMetric]: nextThreshold
+      }
+    };
+  });
 };
 
 /**
@@ -751,10 +764,11 @@ export const setSwatchChangeThreshold = (threshold: number) => {
  */
 export const resetColorState = (theme?: 'light' | 'dark') => {
   constraintSolveRunState.set({ status: 'idle' });
+  clearAutoThemeRestoreLock();
   colorStore.update((currentState) => {
     const targetTheme =
-      theme && THEME_PRESETS[theme] ? theme : (currentState.currentTheme as 'light' | 'dark');
-    const themePreset = THEME_PRESETS[targetTheme];
+      theme && themePresets[theme] ? theme : (currentState.currentTheme as 'light' | 'dark');
+    const themePreset = themePresets[targetTheme];
 
     return normalizeDisplayState({
       ...currentState,
@@ -773,6 +787,7 @@ export const resetColorState = (theme?: 'light' | 'dark') => {
       referenceConfiguration: null,
       comparisonMetric: 'ok' as ColorDifferenceMetric,
       swatchChangeThreshold: 0.02,
+      swatchChangeThresholdsByMetric: structuredClone(DEFAULT_SWATCH_CHANGE_THRESHOLDS_BY_METRIC),
       _lastUpdated: Date.now()
     } as ColorState);
   });

--- a/src/lib/themePresets.ts
+++ b/src/lib/themePresets.ts
@@ -1,0 +1,53 @@
+import type { ContrastReference } from '$lib/types';
+
+function createNeutralContrastReference(stepIndex: number): ContrastReference {
+  return {
+    kind: 'neutral',
+    stepIndex
+  };
+}
+
+export const themePresets = {
+  light: {
+    numColors: 11,
+    numPalettes: 11,
+    baseColor: '#5EF784',
+    warmth: -7,
+    x1: 0.16,
+    y1: 0.0,
+    x2: 0.28,
+    y2: 0.38,
+    chromaMultiplier: 1,
+    contrastMode: 'auto' as const,
+    lowStep: 0,
+    highStep: 10,
+    lowReference: createNeutralContrastReference(0),
+    highReference: createNeutralContrastReference(10),
+    contrast: {
+      low: '#ffffff',
+      high: '#000000'
+    }
+  },
+  dark: {
+    numColors: 11,
+    numPalettes: 11,
+    baseColor: '#5EF784',
+    warmth: -7,
+    x1: 0.45,
+    y1: 0.08,
+    x2: 0.77,
+    y2: 0.96,
+    chromaMultiplier: 0.83,
+    contrastMode: 'auto' as const,
+    lowStep: 2,
+    highStep: 10,
+    lowReference: createNeutralContrastReference(2),
+    highReference: createNeutralContrastReference(10),
+    contrast: {
+      low: '#071531',
+      high: '#ffffff'
+    }
+  }
+} as const;
+
+export type ThemePresetName = keyof typeof themePresets;

--- a/src/routes/PageContent.svelte
+++ b/src/routes/PageContent.svelte
@@ -52,11 +52,14 @@
     referenceConfiguration,
     comparisonMetric,
     swatchChangeThreshold,
+    autoThemeRestoreLock,
     updateColorState,
     updateContrastFromNeutrals,
     resetColorState,
     setTheme,
-    setThemePreference
+    setThemePreference,
+    setAutoThemeRestoreLock,
+    clearAutoThemeRestoreLock
   } from '$lib/stores';
   import { getUrlState, updateBrowserUrl, type UrlColorState } from '$lib/urlUtils';
   import {
@@ -80,8 +83,7 @@
   import type { ReferenceWorkspaceSnapshot } from '$lib/referenceWorkspace';
   import {
     saveReferenceWorkspaceToStorage,
-    loadReferenceWorkspaceFromStorage,
-    clearStoredReferenceWorkspace
+    loadReferenceWorkspaceFromStorage
   } from '$lib/referenceWorkspacePersistence';
   import type { ReferenceConfiguration } from '$lib/referenceConfiguration';
   import { createPageScheduler, type PageScheduler } from '$lib/pageScheduler';
@@ -107,6 +109,8 @@
   import GettingStartedCallout from '$lib/components/GettingStartedCallout.svelte';
   import NoticeBanner from '$lib/components/NoticeBanner.svelte';
   import ReferenceView from '$lib/components/ReferenceView.svelte';
+  import ComparisonControls from '$lib/components/ComparisonControls.svelte';
+  import ConfigurationDiffDisplay from '$lib/components/ConfigurationDiffDisplay.svelte';
   import type { CvdMode } from '$lib/types';
 
   interface Props {
@@ -169,9 +173,17 @@
   let cvdModeLocal = $derived($cvdMode);
   let neutralsSimulatedDisplayLocal = $derived($neutralsSimulatedDisplay);
   let palettesSimulatedDisplayLocal = $derived($palettesSimulatedDisplay);
+  let currentColorStateLocal = $derived($colorStore);
+  let currentComparisonConfig = $derived(
+    currentColorStateLocal as unknown as Record<string, unknown>
+  );
   let referenceConfigurationLocal = $derived($referenceConfiguration);
+  let referenceComparisonConfig = $derived(
+    referenceConfigurationLocal as Record<string, unknown> | null
+  );
   let comparisonMetricLocal = $derived($comparisonMetric);
   let swatchChangeThresholdLocal = $derived($swatchChangeThreshold);
+  let autoThemeRestoreLockLocal = $derived($autoThemeRestoreLock);
 
   // Generated colors from reference configuration (readonly, frozen)
   let referenceColors = $state<ReturnType<typeof generateColorsFromReference> | null>(null);
@@ -322,6 +334,18 @@
     return value === 'WCAG' ? 'WCAG 2.2' : 'APCA';
   }
 
+  function formatResolvedTheme(value: 'light' | 'dark'): string {
+    return value === 'light' ? 'Light' : 'Dark';
+  }
+
+  function getSystemResolvedTheme(): 'light' | 'dark' {
+    if (typeof window === 'undefined') {
+      return 'light';
+    }
+
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
   function formatContrastStepLabel(value: number): string {
     return `${value * 10}`;
   }
@@ -381,6 +405,24 @@
   const activeReferenceViewMode = $derived(
     referenceViewData ? referenceViewData.viewMode : 'default'
   );
+  const resolvedThemeDriftNotice = $derived.by(() => {
+    if (activeReferenceViewMode !== 'comparison' || !referenceConfigurationLocal) {
+      return null;
+    }
+
+    if (
+      themePreferenceLocal !== 'auto' ||
+      referenceConfigurationLocal.themePreference !== 'auto' ||
+      currentThemeLocal === referenceConfigurationLocal.resolvedTheme
+    ) {
+      return null;
+    }
+
+    return {
+      title: `Auto theme currently resolves to ${formatResolvedTheme(currentThemeLocal)}`,
+      body: `The pinned reference was generated in ${formatResolvedTheme(referenceConfigurationLocal.resolvedTheme)}.`
+    };
+  });
 
   function captureReferenceWorkspaceSnapshot(): ReferenceWorkspaceSnapshot {
     const storeState = get(colorStore);
@@ -395,7 +437,8 @@
       referenceConfiguration: storeState.referenceConfiguration as Record<string, unknown> | null,
       viewMode,
       comparisonMetric: comparisonMetricLocal,
-      swatchChangeThreshold: swatchChangeThresholdLocal
+      swatchChangeThreshold: swatchChangeThresholdLocal,
+      swatchChangeThresholdsByMetric: structuredClone(storeState.swatchChangeThresholdsByMetric)
     };
   }
 
@@ -518,7 +561,8 @@
           solverAdjustmentSnapshot: structuredClone(storeState.solverAdjustmentSnapshot),
           constraintSolverSummary: structuredClone(storeState.constraintSolverSummary),
           comparisonMetric: storeState.comparisonMetric,
-          swatchChangeThreshold: storeState.swatchChangeThreshold
+          swatchChangeThreshold: storeState.swatchChangeThreshold,
+          swatchChangeThresholdsByMetric: structuredClone(storeState.swatchChangeThresholdsByMetric)
         },
         reference: captureReferenceWorkspaceSnapshot()
       };
@@ -567,7 +611,10 @@
         solverAdjustmentSnapshot: structuredClone(solverAdjustmentSnapshotLocal),
         constraintSolverSummary: structuredClone(constraintSolverSummaryLocal),
         comparisonMetric: comparisonMetricLocal,
-        swatchChangeThreshold: swatchChangeThresholdLocal
+        swatchChangeThreshold: swatchChangeThresholdLocal,
+        swatchChangeThresholdsByMetric: structuredClone(
+          get(colorStore).swatchChangeThresholdsByMetric
+        )
       },
       reference: captureReferenceWorkspaceSnapshot()
     };
@@ -576,9 +623,23 @@
   function applyHistorySnapshot(snapshot: ReferenceHistorySnapshot): void {
     const palette = snapshot.palette;
     const reference = snapshot.reference;
+    const nextThresholdsByMetric = palette.swatchChangeThresholdsByMetric
+      ? {
+          ...get(colorStore).swatchChangeThresholdsByMetric,
+          ...palette.swatchChangeThresholdsByMetric
+        }
+      : undefined;
 
     skipAutoThemeSync = true;
     isApplyingHistorySnapshot = true;
+    if (palette.themePreference === 'auto' && typeof window !== 'undefined') {
+      const systemResolvedTheme = getSystemResolvedTheme();
+      setAutoThemeRestoreLock(
+        palette.currentTheme !== systemResolvedTheme ? palette.currentTheme : null
+      );
+    } else {
+      clearAutoThemeRestoreLock();
+    }
     pendingHistoryGeneratorSnapshot = {
       baseColor: palette.baseColor,
       warmth: palette.warmth,
@@ -644,6 +705,9 @@
       constraintSolverSummary: palette.constraintSolverSummary,
       comparisonMetric: palette.comparisonMetric,
       swatchChangeThreshold: palette.swatchChangeThreshold,
+      ...(nextThresholdsByMetric && {
+        swatchChangeThresholdsByMetric: nextThresholdsByMetric
+      }),
       referenceConfiguration: reference.referenceConfiguration as ReferenceConfiguration | null
     });
 
@@ -1048,13 +1112,22 @@
     const storedReferenceWorkspace = loadReferenceWorkspaceFromStorage();
     if (storedReferenceWorkspace) {
       referenceViewMode = storedReferenceWorkspace.viewMode;
+      const nextThresholdsByMetric = storedReferenceWorkspace.swatchChangeThresholdsByMetric
+        ? {
+            ...get(colorStore).swatchChangeThresholdsByMetric,
+            ...storedReferenceWorkspace.swatchChangeThresholdsByMetric
+          }
+        : undefined;
       updateColorState({
         ...(storedReferenceWorkspace.referenceConfiguration && {
           referenceConfiguration:
             storedReferenceWorkspace.referenceConfiguration as unknown as ReferenceConfiguration
         }),
         comparisonMetric: storedReferenceWorkspace.comparisonMetric,
-        swatchChangeThreshold: storedReferenceWorkspace.swatchChangeThreshold
+        swatchChangeThreshold: storedReferenceWorkspace.swatchChangeThreshold,
+        ...(nextThresholdsByMetric && {
+          swatchChangeThresholdsByMetric: nextThresholdsByMetric
+        })
       });
     }
 
@@ -1063,7 +1136,15 @@
     const handleMediaChange = (e: MediaQueryListEvent | MediaQueryList) => {
       if ($themePreference === 'auto') {
         const resolvedTheme = e.matches ? 'dark' : 'light';
-        if ($currentTheme !== resolvedTheme) {
+
+        if (autoThemeRestoreLockLocal) {
+          if (resolvedTheme === currentThemeLocal) {
+            clearAutoThemeRestoreLock();
+          }
+          return;
+        }
+
+        if (currentThemeLocal !== resolvedTheme) {
           setTheme(resolvedTheme);
         }
       }
@@ -1100,9 +1181,14 @@
   // React to themePreference changes to apply auto theme
   $effect(() => {
     if (!skipAutoThemeSync && themePreferenceLocal === 'auto' && typeof window !== 'undefined') {
-      const resolvedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
+      const resolvedTheme = getSystemResolvedTheme();
+
+      if (autoThemeRestoreLockLocal) {
+        if (resolvedTheme === currentThemeLocal) {
+          clearAutoThemeRestoreLock();
+        }
+        return;
+      }
 
       if (currentThemeLocal !== resolvedTheme) {
         setTheme(resolvedTheme);
@@ -1259,11 +1345,11 @@
   $effect(() => {
     if (referenceConfigurationLocal) {
       try {
-        referenceColors = generateColorsFromReference(
-          referenceConfigurationLocal,
-          cvdModeLocal,
-          currentThemeLocal
-        );
+        referenceColors = generateColorsFromReference(referenceConfigurationLocal, {
+          cvdMode: cvdModeLocal,
+          displayColorSpace: displayColorSpaceLocal,
+          gamutSpace: gamutSpaceLocal
+        });
       } catch (error) {
         console.error('Error generating reference colors:', error);
         referenceColors = null;
@@ -1343,18 +1429,19 @@
       return;
     }
 
-    const refConfig = referenceConfigurationLocal;
-    if (refConfig) {
-      saveReferenceWorkspaceToStorage({
-        referenceConfiguration: refConfig as unknown as Record<string, unknown>,
-        viewMode: activeReferenceViewMode,
-        comparisonMetric: comparisonMetricLocal,
-        swatchChangeThreshold: swatchChangeThresholdLocal
-      });
-    } else {
+    if (!referenceConfigurationLocal) {
       referenceViewMode = 'default';
-      clearStoredReferenceWorkspace();
     }
+
+    saveReferenceWorkspaceToStorage({
+      referenceConfiguration: referenceConfigurationLocal as Record<string, unknown> | null,
+      viewMode: referenceConfigurationLocal ? activeReferenceViewMode : 'default',
+      comparisonMetric: comparisonMetricLocal,
+      swatchChangeThreshold: swatchChangeThresholdLocal,
+      swatchChangeThresholdsByMetric: structuredClone(
+        get(colorStore).swatchChangeThresholdsByMetric
+      )
+    });
   });
 
   function applyUrlState(urlState: UrlColorState) {
@@ -1588,6 +1675,21 @@
             {/key}
           </Card>
 
+          {#if activeReferenceViewMode === 'comparison'}
+            <Card
+              title="Comparison"
+              subtitle="Difference interpretation"
+              summary={`${comparisonMetricLocal === 'ok' ? 'Delta E OK' : 'Delta E 2000'} · ${swatchChangeThresholdLocal}`}
+              collapsible
+              open={true}
+              data-testid="comparison-controls-card"
+            >
+              {#key `comparison-${historyRestoreRevision}`}
+                <ComparisonControls onHistoryCommit={scheduleHistoryCommit} />
+              {/key}
+            </Card>
+          {/if}
+
           <Card
             title="Output"
             subtitle="Formats and labels"
@@ -1682,6 +1784,18 @@
             {/key}
           </Card>
 
+          {#if activeReferenceViewMode === 'comparison'}
+            <Card
+              title="Comparison"
+              subtitle="Difference interpretation"
+              data-testid="comparison-controls-card"
+            >
+              {#key `comparison-${historyRestoreRevision}`}
+                <ComparisonControls onHistoryCommit={scheduleHistoryCommit} />
+              {/key}
+            </Card>
+          {/if}
+
           <Card title="Output" subtitle="Formats and labels" data-testid="output-controls-card">
             {#key `output-${historyRestoreRevision}`}
               <DisplaySettings
@@ -1765,6 +1879,23 @@
                   ? 'reference-view-tab-comparison'
                   : 'reference-view-tab-reference'}
               >
+                {#if activeReferenceViewMode === 'comparison'}
+                  <div class="comparison-explanations">
+                    {#if resolvedThemeDriftNotice}
+                      <NoticeBanner
+                        tone="info"
+                        title={resolvedThemeDriftNotice.title}
+                        body={resolvedThemeDriftNotice.body}
+                      />
+                    {/if}
+
+                    <ConfigurationDiffDisplay
+                      currentConfig={currentComparisonConfig}
+                      referenceConfig={referenceComparisonConfig}
+                    />
+                  </div>
+                {/if}
+
                 <ReferenceView
                   viewMode={activeReferenceView.viewMode}
                   currentNeutrals={neutralsLocal}
@@ -1787,9 +1918,9 @@
                   referencePalettesDisplay={activeReferenceView.colors.palettesSwatchDisplay}
                   referencePalettesSimulatedDisplay={activeReferenceView.colors
                     .palettesSimulatedDisplay}
+                  referenceCustomNeutralName={activeReferenceView.configuration.customNeutralName}
+                  referenceCustomPaletteNames={activeReferenceView.configuration.customPaletteNames}
                   referenceContrastColors={activeReferenceView.configuration.contrast}
-                  referenceContrastAlgorithm={activeReferenceView.configuration.contrastAlgorithm}
-                  referenceGamutSpace={activeReferenceView.configuration.gamutSpace}
                   onCurrentHistoryCommit={scheduleHistoryCommit}
                 />
               </div>
@@ -1874,6 +2005,11 @@
     display: grid;
     gap: var(--space-md);
     min-height: 0;
+  }
+
+  .comparison-explanations {
+    display: grid;
+    gap: var(--space-md);
   }
 
   .reference-view-tabs {

--- a/src/routes/pageHistory.dom.spec.ts
+++ b/src/routes/pageHistory.dom.spec.ts
@@ -12,6 +12,9 @@ import {
   referenceConfiguration,
   comparisonMetric,
   swatchChangeThreshold,
+  currentTheme,
+  themePreference,
+  setComparisonMetric,
   resetColorState,
   updateColorState
 } from '$lib/stores';
@@ -155,6 +158,22 @@ function getReferenceViewPanel(): HTMLElement {
   return screen.getByRole('tabpanel') as HTMLElement;
 }
 
+function getComparisonControlsCard(): HTMLElement | null {
+  return screen.queryByTestId('comparison-controls-card');
+}
+
+function getComparisonMetricSelect(): HTMLSelectElement {
+  return screen.getByRole('combobox', {
+    name: /select comparison metric for swatch color changes/i
+  }) as HTMLSelectElement;
+}
+
+function getSwatchChangeThresholdInput(): HTMLInputElement {
+  return screen.getByRole('spinbutton', {
+    name: /swatch change threshold value/i
+  }) as HTMLInputElement;
+}
+
 function getUndoHistoryButton(): HTMLButtonElement {
   return screen.getByRole('button', { name: /show undo history/i }) as HTMLButtonElement;
 }
@@ -229,13 +248,13 @@ interface RenderPageOptions {
   openOutputAdvanced?: boolean;
 }
 
-async function renderPage(options: RenderPageOptions = {}): Promise<void> {
+async function renderPage(options: RenderPageOptions = {}) {
   const {
     scheduler = createImmediatePageScheduler(),
     openOutputAdvanced: shouldOpenOutputAdvanced = true
   } = options;
 
-  render(PageContent, { props: { scheduler } });
+  const renderResult = render(PageContent, { props: { scheduler } });
   await flushAppState();
 
   if (shouldOpenOutputAdvanced) {
@@ -244,6 +263,8 @@ async function renderPage(options: RenderPageOptions = {}): Promise<void> {
 
   expect(getUndoButton()).toBeDisabled();
   expect(getRedoButton()).toBeDisabled();
+
+  return renderResult;
 }
 
 async function openFirstConstraintEditor(): Promise<void> {
@@ -385,7 +406,8 @@ describe('page history integration', () => {
     });
     localStorage.clear();
     window.history.replaceState({}, '', '/');
-    updateColorState({ referenceConfiguration: null });
+    resetColorState('light');
+    updateColorState({ themePreference: 'auto', currentTheme: 'light' });
   });
 
   it('supports button undo/redo and multi-step menu jumps', async () => {
@@ -667,9 +689,11 @@ describe('page history integration', () => {
   }, 20000);
 
   it('AC1b: a persisted reference workspace is restored when the page loads', async () => {
+    const validReferenceConfiguration = createReferenceConfiguration(get(colorStore));
+
     // Seed localStorage with a reference workspace before rendering
     const seedWorkspace = {
-      referenceConfiguration: { baseColor: '#5EF784', numColors: 11, pinnedAt: Date.now() },
+      referenceConfiguration: validReferenceConfiguration,
       viewMode: 'reference',
       comparisonMetric: 'ok',
       swatchChangeThreshold: 1
@@ -709,7 +733,7 @@ describe('page history integration', () => {
     expect(get(referenceConfiguration)).toBeNull();
   }, 20000);
 
-  it('AC1c: persisted comparisonMetric and swatchChangeThreshold are restored when the page loads', async () => {
+  it('falls back to per-metric defaults when loading a legacy persisted comparison threshold', async () => {
     const seedWorkspace = {
       referenceConfiguration: { baseColor: '#5EF784', numColors: 11, pinnedAt: Date.now() },
       viewMode: 'reference',
@@ -721,7 +745,79 @@ describe('page history integration', () => {
     await renderPage({ openOutputAdvanced: false });
 
     expect(get(comparisonMetric)).toBe('2000');
-    expect(get(swatchChangeThreshold)).toBe(42);
+    expect(get(swatchChangeThreshold)).toBe(2);
+  }, 20000);
+
+  it('restores remembered thresholds for both comparison metrics when the page loads', async () => {
+    localStorage.setItem(
+      'chroma11y-reference-workspace',
+      JSON.stringify({
+        referenceConfiguration: null,
+        viewMode: 'default',
+        comparisonMetric: 'ok',
+        swatchChangeThreshold: 0.04,
+        swatchChangeThresholdsByMetric: {
+          ok: 0.04,
+          '2000': 3
+        }
+      })
+    );
+
+    await renderPage({ openOutputAdvanced: false });
+
+    expect(get(comparisonMetric)).toBe('ok');
+    expect(get(swatchChangeThreshold)).toBe(0.04);
+
+    setComparisonMetric('2000');
+
+    expect(get(swatchChangeThreshold)).toBe(3);
+  }, 20000);
+
+  it('keeps comparison settings persisted after clearing the reference and reloads them later', async () => {
+    resetColorState('light');
+    const validReferenceConfiguration = createReferenceConfiguration(get(colorStore));
+    localStorage.setItem(
+      'chroma11y-reference-workspace',
+      JSON.stringify({
+        referenceConfiguration: validReferenceConfiguration,
+        viewMode: 'reference',
+        comparisonMetric: '2000',
+        swatchChangeThreshold: 3,
+        swatchChangeThresholdsByMetric: {
+          ok: 0.02,
+          '2000': 3
+        }
+      })
+    );
+
+    const firstRender = await renderPage({ openOutputAdvanced: false });
+
+    await fireEvent.click(
+      screen.getByRole('button', {
+        name: /clear reference configuration and return to default view/i
+      })
+    );
+    await flushAppState();
+
+    expect(JSON.parse(localStorage.getItem('chroma11y-reference-workspace') ?? 'null')).toEqual({
+      referenceConfiguration: null,
+      viewMode: 'default',
+      comparisonMetric: '2000',
+      swatchChangeThreshold: 3,
+      swatchChangeThresholdsByMetric: {
+        ok: 0.02,
+        '2000': 3
+      }
+    });
+
+    firstRender.unmount();
+
+    await renderPage({ openOutputAdvanced: false });
+
+    expect(get(referenceConfiguration)).toBeNull();
+    expect(get(comparisonMetric)).toBe('2000');
+    expect(get(swatchChangeThreshold)).toBe(3);
+    expect(localStorage.getItem('chroma11y-reference-workspace')).not.toBeNull();
   }, 20000);
 
   it('AC201-1: a restored reference workspace exposes explicit reference and comparison view tabs', async () => {
@@ -806,5 +902,198 @@ describe('page history integration', () => {
     expect(referenceTab).toHaveFocus();
     expect(referenceTab).toHaveAttribute('aria-selected', 'true');
     expect(panel).toHaveAttribute('aria-labelledby', 'reference-view-tab-reference');
+  }, 20000);
+
+  it('shows comparison controls only in Comparison View with raw Delta E OK defaults', async () => {
+    const user = userEvent.setup();
+
+    await renderPage({ openOutputAdvanced: false });
+
+    const pinButton = screen.getByRole('button', {
+      name: /pin current palette configuration as reference/i
+    });
+    await fireEvent.click(pinButton);
+    await flushHistoryCommit();
+
+    expect(getComparisonControlsCard()).toBeNull();
+
+    await user.click(getViewTab('Comparison View'));
+    await flushHistoryCommit();
+
+    expect(getComparisonControlsCard()).toBeInTheDocument();
+    expect(getComparisonMetricSelect()).toHaveValue('ok');
+    expect(getSwatchChangeThresholdInput()).toHaveValue(0.02);
+    expect(getSwatchChangeThresholdInput()).toHaveAttribute('min', '0');
+    expect(getSwatchChangeThresholdInput()).toHaveAttribute('max', '0.1');
+    expect(getSwatchChangeThresholdInput()).toHaveAttribute('step', '0.005');
+
+    await user.click(getViewTab('Reference View'));
+    await flushHistoryCommit();
+
+    expect(getComparisonControlsCard()).toBeNull();
+  }, 20000);
+
+  it('restores per-metric comparison thresholds and undoes a metric switch as one step', async () => {
+    const user = userEvent.setup();
+
+    await renderPage({ openOutputAdvanced: false });
+
+    const pinButton = screen.getByRole('button', {
+      name: /pin current palette configuration as reference/i
+    });
+    await fireEvent.click(pinButton);
+    await flushHistoryCommit();
+
+    await user.click(getViewTab('Comparison View'));
+    await flushHistoryCommit();
+
+    const okThresholdInput = getSwatchChangeThresholdInput();
+    okThresholdInput.value = '0.05';
+    await fireEvent.input(okThresholdInput);
+    await fireEvent.change(okThresholdInput);
+    await flushHistoryCommit();
+    expect(getSwatchChangeThresholdInput()).toHaveValue(0.05);
+
+    await fireEvent.change(getComparisonMetricSelect(), { target: { value: '2000' } });
+    await flushHistoryCommit();
+
+    expect(getComparisonMetricSelect()).toHaveValue('2000');
+    expect(getSwatchChangeThresholdInput()).toHaveValue(2);
+
+    const deltaE2000ThresholdInput = getSwatchChangeThresholdInput();
+    deltaE2000ThresholdInput.value = '4';
+    await fireEvent.input(deltaE2000ThresholdInput);
+    await fireEvent.change(deltaE2000ThresholdInput);
+    await flushHistoryCommit();
+    expect(getSwatchChangeThresholdInput()).toHaveValue(4);
+
+    await fireEvent.change(getComparisonMetricSelect(), { target: { value: 'ok' } });
+    await flushHistoryCommit();
+
+    expect(getComparisonMetricSelect()).toHaveValue('ok');
+    expect(getSwatchChangeThresholdInput()).toHaveValue(0.05);
+
+    await user.click(getUndoButton());
+    await flushHistoryCommit();
+
+    expect(getComparisonMetricSelect()).toHaveValue('2000');
+    expect(getSwatchChangeThresholdInput()).toHaveValue(4);
+  }, 20000);
+
+  it('shows resolved theme drift above a no-configuration-changes state in Comparison View', async () => {
+    resetColorState('light');
+    const user = userEvent.setup();
+    let prefersDark = false;
+    const prefersColorSchemeListeners = new Set<(event: MediaQueryListEvent) => void>();
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches:
+          query === '(prefers-color-scheme: dark)'
+            ? prefersDark
+            : query === '(max-width: 980px)'
+              ? false
+              : false,
+        addEventListener: vi.fn((event: string, listener: (next: MediaQueryListEvent) => void) => {
+          if (query === '(prefers-color-scheme: dark)' && event === 'change') {
+            prefersColorSchemeListeners.add(listener);
+          }
+        }),
+        removeEventListener: vi.fn(
+          (event: string, listener: (next: MediaQueryListEvent) => void) => {
+            if (query === '(prefers-color-scheme: dark)' && event === 'change') {
+              prefersColorSchemeListeners.delete(listener);
+            }
+          }
+        )
+      }))
+    });
+
+    await renderPage({ openOutputAdvanced: false });
+
+    const pinButton = screen.getByRole('button', {
+      name: /pin current palette configuration as reference/i
+    });
+    await fireEvent.click(pinButton);
+    await flushHistoryCommit();
+
+    prefersDark = true;
+    for (const listener of prefersColorSchemeListeners) {
+      listener({ matches: true } as MediaQueryListEvent);
+    }
+    await flushAppState();
+
+    expect(get(themePreference)).toBe('auto');
+    expect(get(currentTheme)).toBe('dark');
+    expect(get(referenceConfiguration)?.resolvedTheme).toBe('light');
+
+    await user.click(getViewTab('Comparison View'));
+    await flushHistoryCommit();
+
+    const driftNote = await screen.findByText(/the pinned reference was generated in light/i);
+    const noChangesState = await screen.findByText('No configuration changes');
+
+    expect(driftNote).toBeInTheDocument();
+    expect(noChangesState).toBeInTheDocument();
+    expect(
+      driftNote.compareDocumentPosition(noChangesState) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  }, 20000);
+
+  it('restores the pinned resolved theme exactly when the reference was pinned under auto theme', async () => {
+    resetColorState('light');
+    let prefersDark = false;
+    const prefersColorSchemeListeners = new Set<(event: MediaQueryListEvent) => void>();
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches:
+          query === '(prefers-color-scheme: dark)'
+            ? prefersDark
+            : query === '(max-width: 980px)'
+              ? false
+              : false,
+        addEventListener: vi.fn((event: string, listener: (next: MediaQueryListEvent) => void) => {
+          if (query === '(prefers-color-scheme: dark)' && event === 'change') {
+            prefersColorSchemeListeners.add(listener);
+          }
+        }),
+        removeEventListener: vi.fn(
+          (event: string, listener: (next: MediaQueryListEvent) => void) => {
+            if (query === '(prefers-color-scheme: dark)' && event === 'change') {
+              prefersColorSchemeListeners.delete(listener);
+            }
+          }
+        )
+      }))
+    });
+
+    await renderPage({ openOutputAdvanced: false });
+
+    const pinButton = screen.getByRole('button', {
+      name: /pin current palette configuration as reference/i
+    });
+    await fireEvent.click(pinButton);
+    await flushHistoryCommit();
+
+    prefersDark = true;
+    for (const listener of prefersColorSchemeListeners) {
+      listener({ matches: true } as MediaQueryListEvent);
+    }
+    await flushAppState();
+
+    expect(get(currentTheme)).toBe('dark');
+    expect(get(referenceConfiguration)?.resolvedTheme).toBe('light');
+
+    const restoreButton = screen.getByRole('button', {
+      name: /restore reference configuration into current palette/i
+    });
+    await fireEvent.click(restoreButton);
+    await flushHistoryCommit();
+
+    expect(get(themePreference)).toBe('auto');
+    expect(get(currentTheme)).toBe('light');
   }, 20000);
 });


### PR DESCRIPTION
## Summary

Adds the final comparison-view workflow on top of the stacked reference/comparison branches.
- adds comparison-only controls with metric-specific raw Delta E thresholds and a main-pane `Configuration Diff`
- makes the reference side truly read-only for naming/export flows and keeps reference exports scoped to pinned reference data
- hardens restore and persistence for frozen auto-theme baselines, legacy workspace data, and granular constraint ordering

## Linked Issue(s)

Closes #197
Closes #202

This PR targets `codex/comparison-view-201`, so the closing keywords are also carried in commit `e77de8ff` for when the stack lands in `main`.

## Change Type

- [x] `feat`
- [x] `fix`
- [ ] `tweak`
- [ ] `refactor`
- [ ] `test`
- [ ] `docs`
- [ ] `chore`

## Impacted Areas

- [x] Color generation / contrast logic
- [x] UI components / interactions
- [x] Accessibility / keyboard / screen reader behavior
- [x] URL or localStorage persistence
- [x] Export formats
- [x] Tests / CI workflow
- [ ] Documentation only
- [ ] Dependencies only

## Accessibility Impact

- [ ] No accessibility impact
- [x] Improves accessibility
- [ ] Potential accessibility risk (details below)

### Accessibility Notes

Reference management actions now announce pin/replace/restore/clear events, the reference column is no longer directly editable for naming, and `Configuration Diff` / resolved-theme drift states remain explicit in `Comparison View`.

## Testing

- [x] `npm run lint`
- [x] `npm run check`
- [ ] `npm test`
- [x] Targeted tests run (list below)

### Targeted Tests and Results

- `npm run test:unit -- --run src/routes/pageHistory.dom.spec.ts src/lib/referenceWorkspacePersistence.dom.spec.ts src/lib/comparisonDiff.spec.ts src/lib/stores.spec.ts`
- `npm run test:unit -- --run`
- `npm run test:e2e`

### If Any Standard Check Was Not Run

`npm test` was not run as a single command. The unit and E2E suites were run separately via `npm run test:unit -- --run` and `npm run test:e2e`.

## UI / Visual Evidence (if applicable)

## Risk and Rollback

- Risk level: medium
- Rollback plan: revert commits `e77de8ff`, `82b8a17b`, and `38883160`
